### PR TITLE
Add unit tests

### DIFF
--- a/src/main/node/lib/app.js
+++ b/src/main/node/lib/app.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const Negotiator = require('negotiator');
+
+const SUPPORTED_MEDIA_TYPES = ['text/plain', 'application/json' /*TODO add more*/]; // In preference order
+
+function makeApp(fn) {
+    const app = express();
+
+    app.use('/', bodyParser.text());                            // Supports text/plain
+    app.use('/', bodyParser.raw());                             // Supports application/octet-stream by default
+    app.use('/', bodyParser.json({ strict: false }));           // Supports application/json by default
+    app.use('/', bodyParser.urlencoded({ extended: false }));   // Supports application/x-www-form-urlencoded by default
+
+    app.post('/', function (req, res) {
+        var resultx = fn(req.body);
+        console.log("Result " + resultx);
+
+        negotiator = new Negotiator(req);
+
+        switch (negotiator.mediaType(SUPPORTED_MEDIA_TYPES)) { // returns the most preferred Accept'ed type intersected with our list
+            case 'application/json':
+                res.type("application/json").json(resultx);
+                break;
+            case 'text/plain':
+                // Force text/plain before calling send, as it defaults to html for strings
+                res.type("text/plain").send("" + resultx);
+                break;
+
+        }
+
+        res.status(200);
+    });
+
+    return app;
+}
+
+module.exports = makeApp;

--- a/src/main/node/package-lock.json
+++ b/src/main/node/package-lock.json
@@ -18,6 +18,18 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
@@ -42,10 +54,41 @@
         }
       }
     },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -67,6 +110,18 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -74,6 +129,12 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.1",
@@ -104,6 +165,12 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
     },
     "express": {
       "version": "4.15.5",
@@ -140,6 +207,12 @@
         "vary": "1.1.2"
       }
     },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
     "finalhandler": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
@@ -154,6 +227,23 @@
         "unpipe": "1.0.0"
       }
     },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
+    "formidable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
+      "dev": true
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -163,6 +253,26 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "http-errors": {
       "version": "1.6.2",
@@ -180,6 +290,16 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -189,6 +309,29 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
       "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "jasmine": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
+      "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2",
+        "jasmine-core": "2.8.0"
+      }
+    },
+    "jasmine-core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
+      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -223,6 +366,15 @@
         "mime-db": "1.30.0"
       }
     },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -241,15 +393,36 @@
         "ee-first": "1.1.1"
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
     },
     "proxy-addr": {
       "version": "1.1.5",
@@ -280,6 +453,27 @@
         "iconv-lite": "0.4.19",
         "unpipe": "1.0.0"
       }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "send": {
       "version": "0.15.6",
@@ -322,6 +516,66 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "superagent": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
+      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.1",
+        "debug": "3.1.0",
+        "extend": "3.0.1",
+        "form-data": "2.3.1",
+        "formidable": "1.1.1",
+        "methods": "1.1.2",
+        "mime": "1.6.0",
+        "qs": "6.5.1",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.0.0.tgz",
+      "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
+      "dev": true,
+      "requires": {
+        "methods": "1.1.2",
+        "superagent": "3.8.2"
+      }
+    },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
@@ -336,6 +590,12 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
     "utils-merge": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
@@ -345,6 +605,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/src/main/node/package.json
+++ b/src/main/node/package.json
@@ -5,8 +5,15 @@
   "license": "Apache-2.0",
   "description": "node function invoker for riff",
   "private": true,
+  "scripts": {
+    "test": "jasmine"
+  },
   "dependencies": {
     "body-parser": "^1.18.2",
     "express": "^4.15.5"
+  },
+  "devDependencies": {
+    "jasmine": "^2.8.0",
+    "supertest": "^3.0.0"
   }
 }

--- a/src/main/node/server.js
+++ b/src/main/node/server.js
@@ -1,38 +1,7 @@
-const express = require('express');
-const bodyParser = require('body-parser');
-const Negotiator = require('negotiator');
-
 const PORT = 8080;
-const SUPPORTED_MEDIA_TYPES = ['text/plain', 'application/json' /*TODO add more*/]; // In preference order
 
-const app = express();
-
-app.use('/', bodyParser.text());                            // Supports text/plain
-app.use('/', bodyParser.raw());                             // Supports application/octet-stream by default
-app.use('/', bodyParser.json());                            // Supports application/json by default
-app.use('/', bodyParser.urlencoded({ extended: false }));   // Supports application/x-www-form-urlencoded by default
-
-var fn = require(process.env.FUNCTION_URI);
-
-app.post('/', function (req, res) {
-    var resultx = fn(req.body);
-    console.log("Result " + resultx);
-
-    negotiator = new Negotiator(req);
-
-    switch (negotiator.mediaType(SUPPORTED_MEDIA_TYPES)) { // returns the most preferred Accept'ed type intersected with our list
-        case 'application/json':
-            res.type("application/json").json(resultx);
-            break;
-        case 'text/plain':
-            // Force text/plain before calling send, as it defaults to html for strings
-            res.type("text/plain").send("" + resultx);
-            break;
-
-    }
-
-    res.status(200);
-});
+const fn = require(process.env.FUNCTION_URI);
+const app = require('./lib/app')(fn);
 
 app.listen(PORT);
 console.log('Running on http://localhost:' + PORT);

--- a/src/main/node/spec/appSpec.js
+++ b/src/main/node/spec/appSpec.js
@@ -4,21 +4,21 @@ describe('app', () => {
     const makeApp = require('../lib/app');
     let app;
 
-    beforeEach(() => {
-        app = makeApp(x => x ** 2);
-    });
-
     describe('when plain text is accepted', () => {
+        beforeEach(() => {
+            app = makeApp(name => `Hello ${name}!`);
+        });
+        
         it('should respond with plain text', () => {
             return request(app)
                 .post('/')
                 .accept('text/plain')
                 .type('text/plain')
-                .send('3')
+                .send('riff')
                 .expect(200)
                 .expect('content-type', /plain/)
                 .expect(res => {
-                    expect(res.text).toBe('9');
+                    expect(res.text).toBe('Hello riff!');
                 });
         });
 
@@ -27,26 +27,30 @@ describe('app', () => {
                 .post('/')
                 .accept('text/plain')
                 .type('application/json')
-                .send(3)
+                .send('"riff"')
                 .expect(200)
                 .expect('content-type', /plain/)
                 .expect(res => {
-                    expect(res.text).toBe('9');
+                    expect(res.text).toBe('Hello riff!');
                 });
         });
     });
 
     describe('when JSON is accepted', () => {
+        beforeEach(() => {
+            app = makeApp(({ fahrenheit })  => ({ celsius: (fahrenheit - 32) * 5/9 }));
+        });
+
         it('should respond with JSON', () => {
             return request(app)
                 .post('/')
                 .accept('application/json')
                 .type('application/json')
-                .send(3)
+                .send({ fahrenheit: 212 })
                 .expect(200)
                 .expect('content-type', /json/)
                 .expect(res => {
-                    expect(res.text).toBe('9');
+                    expect(res.body.celsius).toBe(100)
                 });
         });
 
@@ -54,12 +58,12 @@ describe('app', () => {
             return request(app)
                 .post('/')
                 .accept('application/json')
-                .type('text/plain')
-                .send('3')
+                .type('application/x-www-form-urlencoded')
+                .send('fahrenheit=212')
                 .expect(200)
                 .expect('content-type', /json/)
                 .expect(res => {
-                    expect(res.text).toBe('9');
+                    expect(res.body.celsius).toBe(100)
                 });
         });
     });

--- a/src/main/node/spec/appSpec.js
+++ b/src/main/node/spec/appSpec.js
@@ -1,0 +1,66 @@
+const request = require('supertest');
+
+describe('app', () => {
+    const makeApp = require('../lib/app');
+    let app;
+
+    beforeEach(() => {
+        app = makeApp(x => x ** 2);
+    });
+
+    describe('when plain text is accepted', () => {
+        it('should respond with plain text', () => {
+            return request(app)
+                .post('/')
+                .accept('text/plain')
+                .type('text/plain')
+                .send('3')
+                .expect(200)
+                .expect('content-type', /plain/)
+                .expect(res => {
+                    expect(res.text).toBe('9');
+                });
+        });
+
+        it('should respond with plain text, even when sending another context type', () => {
+            return request(app)
+                .post('/')
+                .accept('text/plain')
+                .type('application/json')
+                .send(3)
+                .expect(200)
+                .expect('content-type', /plain/)
+                .expect(res => {
+                    expect(res.text).toBe('9');
+                });
+        });
+    });
+
+    describe('when JSON is accepted', () => {
+        it('should respond with JSON', () => {
+            return request(app)
+                .post('/')
+                .accept('application/json')
+                .type('application/json')
+                .send(3)
+                .expect(200)
+                .expect('content-type', /json/)
+                .expect(res => {
+                    expect(res.text).toBe('9');
+                });
+        });
+
+        it('should respond with JSON, even when sending another content type', () => {
+            return request(app)
+                .post('/')
+                .accept('application/json')
+                .type('text/plain')
+                .send('3')
+                .expect(200)
+                .expect('content-type', /json/)
+                .expect(res => {
+                    expect(res.text).toBe('9');
+                });
+        });
+    });
+});

--- a/src/main/node/spec/support/jasmine.json
+++ b/src/main/node/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
Uses Jasmine and SuperAgent to unit test the function invoker and
HTTP protocol. The bulk of the server code has moved into lib/app.js
in order to make testing easier without needing to bootstrap and
configure a full server process. The app module is a function that
accepts the target function to invoke and returns a configured express
application that is **not** yet listening to a port.

To execute the tests:
- `cd src/main/node`
- `npm install`
- `npm test`