### PR TITLE
Add async function support

### DIFF
--- a/src/main/node/lib/app.js
+++ b/src/main/node/lib/app.js
@@ -1,3 +1,5 @@
+const logger = require('util').debuglog('riff');
+
 const express = require('express');
 const bodyParser = require('body-parser');
 const Negotiator = require('negotiator');
@@ -21,7 +23,7 @@ function makeApp(fn) {
 
     app.post('/', asyncMiddleware(async (req, res) => {
         const resultx = await fn(req.body);
-        console.log("Result " + resultx);
+        logger('Result:', resultx);
 
         negotiator = new Negotiator(req);
 
@@ -38,6 +40,12 @@ function makeApp(fn) {
 
         res.status(200);
     }));
+
+    // handle errors
+    app.use((err, req, res, next) => {
+        logger('Error:', err);
+        res.status(500).end();
+    });
 
     return app;
 }

--- a/src/main/node/lib/app.js
+++ b/src/main/node/lib/app.js
@@ -4,6 +4,13 @@ const Negotiator = require('negotiator');
 
 const SUPPORTED_MEDIA_TYPES = ['text/plain', 'application/json' /*TODO add more*/]; // In preference order
 
+function asyncMiddleware(middleware) {
+    return (req, res, next) => {
+        // handles thrown errors from middleware
+        middleware(req, res, next).catch(err => next(err));
+    };
+}
+
 function makeApp(fn) {
     const app = express();
 
@@ -12,8 +19,8 @@ function makeApp(fn) {
     app.use('/', bodyParser.json({ strict: false }));           // Supports application/json by default
     app.use('/', bodyParser.urlencoded({ extended: false }));   // Supports application/x-www-form-urlencoded by default
 
-    app.post('/', function (req, res) {
-        var resultx = fn(req.body);
+    app.post('/', asyncMiddleware(async (req, res) => {
+        const resultx = await fn(req.body);
         console.log("Result " + resultx);
 
         negotiator = new Negotiator(req);
@@ -30,7 +37,7 @@ function makeApp(fn) {
         }
 
         res.status(200);
-    });
+    }));
 
     return app;
 }

--- a/src/main/node/spec/appSpec.js
+++ b/src/main/node/spec/appSpec.js
@@ -4,6 +4,60 @@ describe('app', () => {
     const makeApp = require('../lib/app');
     let app;
 
+    describe('when functions throw', () => {
+        beforeEach(() => {
+            app = makeApp(() => { throw new Error(); });
+        });
+
+        it('should respond with a 500', () => {
+            return request(app)
+                .post('/')
+                .expect(500);
+        });
+    });
+
+    describe('when async functions are invoked', () => {
+        beforeEach(() => {
+            app = makeApp(async name => `Hello ${name}!`);
+        });
+
+        it('should respond with the result', () => {
+            return request(app)
+                .post('/')
+                .accept('text/plain')
+                .type('text/plain')
+                .send('riff')
+                .expect(200)
+                .expect('content-type', /plain/)
+                .expect(res => {
+                    expect(res.text).toBe('Hello riff!');
+                });
+        });
+    });
+
+    describe('when functions return a Promise', () => {
+        beforeEach(() => {
+            app = makeApp(name => {
+                return new Promise(resolve => {
+                    resolve(`Hello ${name}!`);
+                });
+            });
+        });
+
+        it('should respond with the result', () => {
+            return request(app)
+                .post('/')
+                .accept('text/plain')
+                .type('text/plain')
+                .send('riff')
+                .expect(200)
+                .expect('content-type', /plain/)
+                .expect(res => {
+                    expect(res.text).toBe('Hello riff!');
+                });
+        });
+    });
+
     describe('when plain text is accepted', () => {
         beforeEach(() => {
             app = makeApp(name => `Hello ${name}!`);


### PR DESCRIPTION
Either async or Promised function can now be used in addition to
traditional synchronous functions. Node-style callback functions are
not supported.

```js
// sync
module.exports = name => `Hello ${name}!`;

// promise
module.exports = name => Promise.resolve(`Hello ${name}!`);

// async
module.exports = async name => `Hello ${name}!`;
```

Issue: #7