### PR TITLE
Quickly and cleanly shutdown the invoker when done

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,22 @@
+const starttime = Date.now();
+
 const PORT = 8080;
 
 const fn = require(process.env.FUNCTION_URI);
 const app = require('./lib/app')(fn);
 
-app.listen(PORT);
+const server = app.listen(PORT);
 console.log('Running on http://localhost:' + PORT);
+
+function shutdown() {
+    console.log(`Server shutdown, ${((Date.now() - starttime) / 1000).toFixed(1)}s uptime`);
+
+    // wait 10s for the sever to exit gracefully before killing it
+    setTimeout(() => process.exit(-1), 10e3);
+
+    // gracefully exit
+    server.close(() => process.exit(0));
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);


### PR DESCRIPTION
Previously, the invoker would remain up for about a minute after being
told to scale down before finally exiting. Now the node process will
shutdown the server and exit the process when a shutdown signal is
recieved.

Open HTTP connections are allowed up to 10 seconds to finish before the
process exits.

Fixes: #13