### PR TITLE
Handle Content-Type headers with a charset

### DIFF
--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -50,8 +50,8 @@ function makeServer(fn) {
                 const { payload } = message;
                 const headers = MessageHeaders.fromObject(message.headers);
 
-                // TODO case insensitive headers
-                const contentType = headers.getValue('Content-Type') || 'text/plain';
+                // TODO correctly handle content-type charset, instead of ignoring it
+                const contentType = (headers.getValue('Content-Type') || 'text/plain').split(';')[0].trim();
                 const accept = headers.getValue('Accept') || 'text/plain';
                 const correlationId = headers.getValue('correlationId');
 

--- a/spec/grpcSpec.js
+++ b/spec/grpcSpec.js
@@ -348,6 +348,58 @@ describe('grpc', () => {
             call.end();
         });
 
+        it('should handle a content-type charset', done => {
+            const call = client.call();
+            const onData = jasmine.createSpy('onData');
+            const onEnd = () => {
+                expect(fn).toHaveBeenCalledTimes(1);
+                expect(fn).toHaveBeenCalledWith('riff');
+
+                expect(onData).toHaveBeenCalledTimes(1);
+                const { headers, payload } = parseMessage(onData.calls.first().args[0]);
+                expect(headers.getValues('Content-Type')).toEqual(['text/plain']);
+                expect(payload.toString()).toBe('riff');
+
+                done();
+            };
+            call.on('data', onData);
+            call.on('end', onEnd);
+            call.write(
+                new MessageBuilder()
+                    .addHeader('Accept', 'text/plain')
+                    .addHeader('Content-Type', 'text/plain; charset=utf-8')
+                    .payload('riff')
+                    .build()
+            );
+            call.end();
+        });
+
+        it('should handle compound accept types', done => {
+            const call = client.call();
+            const onData = jasmine.createSpy('onData');
+            const onEnd = () => {
+                expect(fn).toHaveBeenCalledTimes(1);
+                expect(fn).toHaveBeenCalledWith('riff');
+
+                expect(onData).toHaveBeenCalledTimes(1);
+                const { headers, payload } = parseMessage(onData.calls.first().args[0]);
+                expect(headers.getValues('Content-Type')).toEqual(['text/plain']);
+                expect(payload.toString()).toBe('riff');
+
+                done();
+            };
+            call.on('data', onData);
+            call.on('end', onEnd);
+            call.write(
+                new MessageBuilder()
+                    .addHeader('Accept', 'application/json;q=0.5, text/plain')
+                    .addHeader('Content-Type', 'text/plain')
+                    .payload('riff')
+                    .build()
+            );
+            call.end();
+        });
+
         it('should reject unsupported content types', done => {
             const call = client.call();
             const onData = jasmine.createSpy('onData');


### PR DESCRIPTION
The Content-Type header can also contain a charset param.

```http
Content-Type: text/plain; charset=utf-8
```

Previously this would cause the gRPC handler to choke. Now the charset
is ignored. In the future we should correctly parse the charset and
decode the payload accordingly. For now, all text content is assumed to
be utf-8.

Fixes: #29