### PR TITLE
Allow functions to receive messages or payloads

### DIFF
--- a/lib/argument-types.js
+++ b/lib/argument-types.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+    HEADERS: 'headers',
+    MESSAGE: 'message',
+    PAYLOAD: 'payload'
+};

--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -17,8 +17,10 @@
 const logger = require('util').debuglog('riff');
 
 const interactionModelTypes = require('./interaction-models');
+const argumentTypes = require('./argument-types');
 
-const { FunctionInvokerService, MessageBuilder, MessageHeaders } = require('@projectriff/function-proto');
+const { FunctionInvokerService } = require('@projectriff/function-proto');
+const { Message, AbstractMessage, AbstractHeaders } = require('@projectriff/message');
 const grpc = require('grpc');
 const through2 = require('through2');
 
@@ -44,18 +46,32 @@ const mediaTypeMarshallers = {
     }
 };
 
-const interactionModels = {
-    [interactionModelTypes.NODE_STREAMS](fn, grpcStream) {
+const argumentTransforms = {
+    [argumentTypes.MESSAGE]({ headers, payload }) {
+        return AbstractMessage.fromRiffMessage({
+            headers: headers.toRiffHeaders(),
+            payload
+        });
+    },
+    [argumentTypes.HEADERS]({ headers }) {
+        return AbstractHeaders.fromRiffHeaders(headers.toRiffHeaders());
+    },
+    [argumentTypes.PAYLOAD]({ payload }) {
+        return payload;
+    }
+};
+
+const interactionModelServices = {
+    [interactionModelTypes.NODE_STREAMS](fn, argumentTransform, grpcStream) {
         const { grpcToFn, fnToGRPC } = makeFunctionStreams(grpcStream, {
-            defaultContentType: fn.$defaultContentType || 'text/plain'
+            defaultContentType: fn.$defaultContentType || 'text/plain',
+            argumentTransform
         });
         fn(grpcToFn, fnToGRPC);
     },
-    [interactionModelTypes.REQUEST_REPLY](fn, grpcStream) {
+    [interactionModelTypes.REQUEST_REPLY](fn, argumentTransform, grpcStream) {
         const requestReplyStream = through2.obj(async function (message, enc, callback) {
-            const { payload } = message;
-            const headers = MessageHeaders.fromObject(message.headers);
-
+            const { headers, payload } = Message.fromRiffMessage(message);
             const correlationId = headers.getValue('correlationId');
 
             try {
@@ -66,27 +82,28 @@ const interactionModels = {
 
                 // convert payloads and invoke function
                 const unmarshalledInput = parseMessage(payload, { contentType })
-                const output = await fn(unmarshalledInput);
-
+                const unmarshalledMessage = new Message(headers, unmarshalledInput);
+                const output = await fn(argumentTransform(unmarshalledMessage));
                 const responseMessage = buildMessage(output, { correlationId, contentType: accept });
-                callback(null, responseMessage);
+                callback(null, responseMessage.toRiffMessage());
             } catch (err) {
                 const errorMessage = buildErrorMessage(err, { correlationId });
-                callback(null, errorMessage);
+                callback(null, errorMessage.toRiffMessage());
             }
         });
         grpcStream.pipe(requestReplyStream).pipe(grpcStream);
     }
 };
 
-function makeServer(fn, interactionModel) {
-    let service = interactionModels[interactionModel];
-    if (!service) return;
+function makeServer(fn, interactionModel, argumentType) {
+    let service = interactionModelServices[interactionModel];
+    let argumentTransform = argumentTransforms[argumentType];
+    if (!service || !argumentTransform) return;
 
     const server = new grpc.Server();
     server.addService(FunctionInvokerService, {
         call(grpcStream) {
-            service(fn, grpcStream);
+            service(fn, argumentTransform, grpcStream);
         }
     });
 
@@ -113,21 +130,22 @@ function canUnmarshall(type) {
     return !!unmarshall;
 }
 
-function makeFunctionStreams(grpcStream, { defaultContentType } = {}) {
+function makeFunctionStreams(grpcStream, { defaultContentType, argumentTransform }) {
     // create transforming streams
-    const grpcToFn = through2.obj(function (message, enc, callback) {
-        const headers = MessageHeaders.fromObject(message.headers);
+    const grpcToFn = through2.obj(function (chunk, enc, callback) {
+        const { headers, payload } = Message.fromRiffMessage(chunk);
         try {
             const { contentType } = determineContentTypes(headers);
             if (!canUnmarshall(contentType)) throw new RiffError('error-client-content-type-unsupported');
-            const chunk = parseMessage(message.payload, { contentType });
-            this.push(chunk);
+            const unmarshalledPayload = parseMessage(payload, { contentType });
+            const message = argumentTransform(new Message(headers, unmarshalledPayload));
+            this.push(message);
         } catch (e) {
             const errorMessage = buildErrorMessage(e, {
                 correlationId: headers.getValue('correlationId')
             });
             // write errors directly to grpcStream
-            grpcStream.write(errorMessage);
+            grpcStream.write(errorMessage.toRiffMessage());
         }
         callback();
     });
@@ -136,10 +154,9 @@ function makeFunctionStreams(grpcStream, { defaultContentType } = {}) {
             // TODO allow override of contentType
             contentType: defaultContentType
         });
-        this.push(message);
+        this.push(message.toRiffMessage());
         callback();
     });
-
 
     // connect streams
     grpcStream.pipe(grpcToFn);
@@ -162,18 +179,27 @@ function parseMessage(payload, { contentType }) {
     return unmarshalledInput;
 }
 
-function buildMessage(payload, { contentType, correlationId } = {}) {
+function buildMessage(message, { contentType, correlationId } = {}) {
+    if (message instanceof AbstractMessage) {
+        // convert to Message
+        message = new Message(message);
+    } else {
+        // convert generic payload to a Message
+        message = new Message({}, message);
+    }
+    const { headers, payload } = message;
     try {
         const { marshall } = mediaTypeMarshallers[contentType] || {};
         // TODO is this error type still appropriate
         if (!marshall) throw new RiffError('error-client-accept-type-unsupported');
         const marshalledOutput = attempt(marshall, payload, 'error-client-marshall');
         logger('Result:', marshalledOutput);
-        let messageBuilder = new MessageBuilder()
-            .addHeader('Content-Type', contentType)
+        let messageBuilder = Message.builder()
+            .headers(headers)
+            .replaceHeader('Content-Type', contentType)
             .payload(marshalledOutput);
         if (correlationId) {
-            messageBuilder = messageBuilder.addHeader('correlationId', correlationId)
+            messageBuilder = messageBuilder.replaceHeader('correlationId', correlationId)
         }
         return messageBuilder.build();
     } catch (e) {
@@ -184,18 +210,18 @@ function buildMessage(payload, { contentType, correlationId } = {}) {
 function buildErrorMessage(err, { correlationId } = {}) {
     logger('Error:', err);
 
-    let messageBuilder = new MessageBuilder();
+    let messageBuilder = Message.builder();
     if (err instanceof RiffError) {
         messageBuilder = messageBuilder
-            .addHeader('error', err.type)
+            .replaceHeader('error', err.type)
             .payload(err.cause ? err.cause.stack || ('' + err.cause) : '');
     } else {
         messageBuilder = messageBuilder
-            .addHeader('error', 'error-server-function-invocation')
+            .replaceHeader('error', 'error-server-function-invocation')
             .payload('' + (err && err.stack || err));
     }
     if (correlationId) {
-        messageBuilder = messageBuilder.addHeader('correlationId', correlationId)
+        messageBuilder = messageBuilder.replaceHeader('correlationId', correlationId)
     }
     return messageBuilder.build();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,11 @@
       "resolved": "https://registry.npmjs.org/@projectriff/function-proto/-/function-proto-0.0.4.tgz",
       "integrity": "sha512-A3nT6IE2vbjEP/e8xnHBry9auELHiWWt5Q/JRIVNaNkfd5FCOtSnDwDcPzqex2WsROJtiX+45B85pL4eG/uBqg=="
     },
+    "@projectriff/message": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@projectriff/message/-/message-1.0.0-beta.3.tgz",
+      "integrity": "sha512-QJvXzvs1OKClMLagr0PfecQTT4NYAg1dF3QROgMF7/gNrXHC7xiard9pn/RHbE1pZTnQ+gPvXzJfglcfB/IDjg=="
+    },
     "acorn": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
@@ -489,12 +494,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "external-editor": {
@@ -1490,20 +1489,19 @@
       "dev": true
     },
     "jasmine": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
-      "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.1.0.tgz",
+      "integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
       "dev": true,
       "requires": {
-        "exit": "0.1.2",
         "glob": "7.1.2",
-        "jasmine-core": "2.8.0"
+        "jasmine-core": "3.1.0"
       }
     },
     "jasmine-core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
-      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
+      "integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw=",
       "dev": true
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@projectriff/function-proto": "0.0.4",
+    "@projectriff/message": "1.0.0-beta.3",
     "grpc": "^1.8.4",
     "negotiator": "^0.6.1",
     "through2": "^2.0.3"

--- a/spec/support/uppercase-custom-message.js
+++ b/spec/support/uppercase-custom-message.js
@@ -1,0 +1,32 @@
+const { AbstractMessage } = require('@projectriff/message');
+
+class AltMessage extends AbstractMessage {
+    constructor(payload) {
+        super()
+        this.payload = payload;
+    }
+    toRiffMessage() {
+        return {
+            headers: {
+                'x-test': {
+                    values: [
+                        'uppercase-custom-message'
+                    ]
+                }
+            },
+            payload: this.payload
+        };
+    }
+}
+
+AbstractMessage.fromRiffMessage = function(message) {
+    return new AltMessage(message.payload);
+};
+
+module.exports = message => {
+    if (!(message instanceof AltMessage)) {
+        throw new Error('Unexpected message type');
+    }
+    return new AltMessage(message.payload.toUpperCase());
+};
+module.exports.$argumentType = 'message';

--- a/spec/support/uppercase-headers.js
+++ b/spec/support/uppercase-headers.js
@@ -1,0 +1,4 @@
+module.exports = headers => {
+    return headers.getValue('content-type').toUpperCase();
+};
+module.exports.$argumentType = 'headers';

--- a/spec/support/uppercase-message.js
+++ b/spec/support/uppercase-message.js
@@ -1,0 +1,11 @@
+const { Message } = require('@projectriff/message');
+
+Message.install();
+
+module.exports = message => {
+    if (!(message instanceof Message)) {
+        throw new Error('Unknown message type');
+    }
+    return message.payload.toUpperCase();
+};
+module.exports.$argumentType = 'message';

--- a/spec/support/uppercase-payload.js
+++ b/spec/support/uppercase-payload.js
@@ -1,0 +1,4 @@
+module.exports = payload => {
+    return payload.toUpperCase();
+};
+module.exports.$argumentType = 'payload';

--- a/spec/support/uppercase-produces-message.js
+++ b/spec/support/uppercase-produces-message.js
@@ -1,0 +1,9 @@
+const { Message } = require('@projectriff/message');
+
+module.exports = message => {
+    console.log('message', message);
+    return Message.builder()
+        .addHeader('X-Test', 'uppercase-produces-message')
+        .payload(message.toUpperCase())
+        .build();
+};


### PR DESCRIPTION
Currently, functions only receive message payloads when the function is
invoked. This is akin to an HTTP server that can only the the entity of
a request, or worse, can only set the entity of a response. Each message
in riff contains headers in addition to the payload.

Now functions can opt-in to receive messages or headers. Payloads are
still available by default.

```js
module.exports = message => {
    // validate GitHub WebHook signature
    const signature = message.headers.getValue('X-Hub-Signature');
    ...
};
module.exports.$argumentType = 'message';
```

The [@projectriff/message](https://github.com/projectriff/node-message) repository defines the Message and Headers types that are used. They:

- convert to and from the raw format defined by [function-proto](https://github.com/projectriff/riff/tree/master/function-proto)
- treat header names as case insensitive, while also case preserving
- handle multiple header values
- are immutable
- use a fluent builder pattern to create messages

The npm package can be installed and required by your function to
produce a message with custom headers. Any function that emits a value
that is an instance of Message will be treated as a message, otherwise,
it will be treated as a payload.

```js
const { Message } = require('@projectriff/message');

let count = 0;
let instance = Math.round(Math.random() * 10000)

module.exports = name => {
    return Message.builder()
        .addHeader('X-Instance-ID', instance)
        .addHeader('X-Instance-Count', count++)
        .payload(`Hello ${name}!`)
        .build();
};
```

Issue: #41