### PR TITLE
Maintain backpressure for request-reply model

### DIFF
--- a/lib/grpc.js
+++ b/lib/grpc.js
@@ -52,7 +52,7 @@ const interactionModels = {
         fn(grpcToFn, fnToGRPC);
     },
     [interactionModelTypes.REQUEST_REPLY](fn, grpcStream) {
-        grpcStream.on('data', async message => {
+        const requestReplyStream = through2.obj(async function (message, enc, callback) {
             const { payload } = message;
             const headers = MessageHeaders.fromObject(message.headers);
 
@@ -69,15 +69,13 @@ const interactionModels = {
                 const output = await fn(unmarshalledInput);
 
                 const responseMessage = buildMessage(output, { correlationId, contentType: accept });
-                grpcStream.write(responseMessage);
+                callback(null, responseMessage);
             } catch (err) {
                 const errorMessage = buildErrorMessage(err, { correlationId });
-                grpcStream.write(errorMessage);
+                callback(null, errorMessage);
             }
         });
-        grpcStream.on('end', () => {
-            grpcStream.end();
-        });
+        grpcStream.pipe(requestReplyStream).pipe(grpcStream);
     }
 };
 


### PR DESCRIPTION
Using `stream.on('data', func)` loses backpressure. By using a
transforming stream, backpressure is maintained.