### PR TITLE
Add tests to enforce version sameness

### DIFF
--- a/node-invoker.yaml
+++ b/node-invoker.yaml
@@ -4,7 +4,7 @@ kind: Invoker
 metadata:
   name: node
 spec:
-  version: 0.0.7-snapshot
+  version: 0.0.8-snapshot
   matchers:
   - package.json
   - "*.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
@@ -527,7 +527,7 @@
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
         "is-resolvable": "1.1.0",
-        "js-yaml": "3.10.0",
+        "js-yaml": "3.11.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.5",
@@ -1778,12 +1778,12 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
+        "argparse": "1.0.10",
         "esprima": "4.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint": "^4.17.0",
     "eslint-plugin-jasmine": "^2.9.2",
     "jasmine": "^3.1.0",
+    "js-yaml": "^3.11.0",
     "supertest": "^3.0.0",
     "wait-for-port": "0.0.2"
   }

--- a/spec/version.spec.js
+++ b/spec/version.spec.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+fdescribe('version', () => {
+
+    const { version } = require('../package.json');
+
+    it('matches the package lock version', async () => {
+        const packageLock = require('../package-lock.json');
+        expect(packageLock.version).toBe(version);
+    });
+
+    it('matches the invoker.yaml version', async () => {
+        const filepath = path.resolve(__dirname, '..', 'node-invoker.yaml');
+        const invokerResource = yaml.safeLoad(fs.readFileSync(filepath, 'utf8'));
+        expect(invokerResource.spec.version).toBe(version);
+    });
+
+    if (process.env.TRAVIS_TAG) {
+        it('matches the tag name', () => {
+            expect(process.env.TRAVIS_TAG).toBe(`v${version}`);
+        });
+    }
+
+});

--- a/spec/version.spec.js
+++ b/spec/version.spec.js
@@ -18,7 +18,7 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
-fdescribe('version', () => {
+describe('version', () => {
 
     const { version } = require('../package.json');
 


### PR DESCRIPTION
The following files should always contain the same version number:
- package.json
- package-lock.json
- node-invoker.yaml

In addition, these versions should match the tag (when tagged).

Fixes #53