### PR TITLE
Only start the needed protocol server

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/node_modules
+/samples


### PR DESCRIPTION
Functions define the protocol they expect to be invoked on. The inovker
only needs to start the server for the selected protocol. The function
controller will now set RIFF_FUNCTION_INVOKER_PROTOCOL with the value
of the protocol the sidecar will use to connect to the inovker.

When the RIFF_FUNCTION_INVOKER_PROTOCOL value is set to 'http', the grpc
server doesn't need to start, and vice-versa.

Refs projectriff/riff#549