### PR TITLE
fix: provide default values for port and host

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@
  */
 
 const { FUNCTION_URI, RIFF_FUNCTION_INVOKER_PROTOCOL } = process.env;
-const PORT = process.env.PORT || 8080;
+const PORT = process.env.HTTP_PORT || process.env.PORT || '8080';
 const HOST = process.env.HOST || '0.0.0.0';
 
 const interactionModels = require('./lib/interaction-models');

--- a/server.js
+++ b/server.js
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-const { FUNCTION_URI, HOST, RIFF_FUNCTION_INVOKER_PROTOCOL, HTTP_PORT } = process.env;
+const { FUNCTION_URI, RIFF_FUNCTION_INVOKER_PROTOCOL } = process.env;
+const PORT = process.env.PORT || 8080;
+const HOST = process.env.HOST || '0.0.0.0';
 
 const interactionModels = require('./lib/interaction-models');
 const argumentTransformers = require('./lib/argument-transformers');
@@ -58,8 +60,8 @@ function loadHTTP(interactionModel, argumentTransformer) {
     const app = require('./lib/protocols/http')(fn, interactionModel, argumentTransformer);
 
     return () => {
-        const server = app.listen(HTTP_PORT, HOST);
-        console.log(`HTTP running on ${HOST === '0.0.0.0' ? 'localhost' : HOST}:${HTTP_PORT}`);
+        const server = app.listen(PORT, HOST);
+        console.log(`HTTP running on ${HOST === '0.0.0.0' ? 'localhost' : HOST}:${PORT}`);
         return server;
     };
 }

--- a/spec/server.spec.js
+++ b/spec/server.spec.js
@@ -23,7 +23,7 @@ const { Message, Headers } = require('@projectriff/message');
 const request = require('superagent');
 
 const HOST = process.env.HOST || '127.0.0.1';
-const PORT = 8080;
+const PORT = process.PORT || '8080';
 
 const serverPath = path.join(__dirname, '..', 'server.js');
 

--- a/spec/server.spec.js
+++ b/spec/server.spec.js
@@ -23,7 +23,7 @@ const { Message, Headers } = require('@projectriff/message');
 const request = require('superagent');
 
 const HOST = process.env.HOST || '127.0.0.1';
-const HTTP_PORT = 8080;
+const PORT = 8080;
 
 const serverPath = path.join(__dirname, '..', 'server.js');
 
@@ -34,8 +34,6 @@ describe('server', () => {
 
         return childProcess.spawn('node', [serverPath], {
             env: Object.assign({}, process.env, {
-                HOST,
-                HTTP_PORT,
                 RIFF_FUNCTION_INVOKER_PROTOCOL: protocol,
                 FUNCTION_URI: path.join(__dirname, 'support', `${functionName}.js`)
             }),
@@ -45,14 +43,14 @@ describe('server', () => {
 
     async function waitForServer(protocol = '') {
         if (!protocol || protocol === 'http') {
-            await waitForPort(HOST, HTTP_PORT, { numRetries: 10, retryInterval: 100 });
+            await waitForPort(HOST, PORT, { numRetries: 10, retryInterval: 100 });
         }
     }
 
     function requestReplyCall(input) {
         return new Promise((resolve, reject) => {
             let req = request
-                .post(`http://${HOST}:${HTTP_PORT}/`)
+                .post(`http://${HOST}:${PORT}/`)
                 .send(input.payload);
 
             // copy headers
@@ -381,7 +379,7 @@ describe('server', () => {
         // http request
         await new Promise(resolve => {
             request
-                .post(`http://localhost:${HTTP_PORT}/`)
+                .post(`http://localhost:${PORT}/`)
                 .set('Content-Type', 'text/plain')
                 .send('riff')
                 .end(function(err, res) {
@@ -412,7 +410,7 @@ describe('server', () => {
 
         await new Promise(resolve => {
             request
-                .post(`http://localhost:${HTTP_PORT}/`)
+                .post(`http://localhost:${PORT}/`)
                 .set('Content-Type', 'text/plain')
                 .send('riff')
                 .end(function(err, res) {


### PR DESCRIPTION
This is the first of a two part change to remove setting default PORT and HOST values from the image layer inside the [node-function-buildpack](https://github.com/projectriff/node-function-buildpack/blob/master/node/riff_invoker.go#L99-L105), Build phase.  

The builder should only care about building the image and less about server configuration, so this change is to provide default values for the `PORT` and `HOST`, if not already set via ENV vars.

