### PR TITLE
Support structured cloudevents using the JSON event format.

### DIFF
--- a/lib/interaction-models/content-negotiation.js
+++ b/lib/interaction-models/content-negotiation.js
@@ -17,7 +17,7 @@
 const mediaTypeNegotiator = require('negotiator/lib/mediaType');
 const querystring = require('querystring');
 
-const SUPPORTED_MEDIA_TYPES = ['text/plain', 'application/octet-stream', 'application/json', 'application/x-www-form-urlencoded']; // In preference order
+const SUPPORTED_MEDIA_TYPES = ['text/plain', 'application/octet-stream', 'application/json', 'application/x-www-form-urlencoded', 'application/cloudevents+json']; // In preference order
 
 const mediaTypeMarshallers = {
     'application/octet-stream': {
@@ -35,7 +35,11 @@ const mediaTypeMarshallers = {
     'application/x-www-form-urlencoded': {
         unmarshall: buffer => querystring.parse('' + buffer),
         marshall: object => Buffer.from(querystring.stringify(object))
-    }
+    },
+    'application/cloudevents+json': {
+        unmarshall: buffer => JSON.parse('' + buffer),
+        marshall: object => Buffer.from(JSON.stringify(object))
+    },
 };
 
 function canMarshall(type) {

--- a/spec/http-prototcol.spec.js
+++ b/spec/http-prototcol.spec.js
@@ -740,6 +740,27 @@ describe('http', () => {
                 });
         });
 
+        it('should handle structured cloudevents', done => {
+            request(app)
+                .post('/')
+                .set('Accept', 'application/cloudevents+json')
+                .set('Content-Type', 'application/cloudevents+json')
+                .send('"riff"')
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) throw err;
+
+                    expect(fn).toHaveBeenCalledTimes(1);
+                    expect(fn).toHaveBeenCalledWith('riff');
+
+                    expect(res.headers['content-type']).toEqual('application/cloudevents+json');
+                    expect(res.headers['error']).toBeUndefined();
+                    expect(res.text).toEqual('"riff"');
+
+                    done();
+                });
+        });
+
         it('should handle binary data', done => {
             request(app)
                 .post('/')


### PR DESCRIPTION
Allow `application/cloudevents+json` to be accepted and marshalled in the same way  as `application/json`.

https://github.com/cloudevents/spec/blob/master/http-transport-binding.md#3-http-message-mapping

#88 was opened to discuss as well. 