### PR TITLE
[#98] Move function promotion to streaming pipeline init

### DIFF
--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -1,18 +1,17 @@
 const StreamingPipeline = require('./streaming-pipeline');
 const services = require('../codegen/proto/riff-rpc_grpc_pb');
-const promoteRequestReplyFunction = require('./request-reply-promoter');
 const logger = require('util').debuglog('riff');
 const grpc = require('grpc');
 
 function lookUpFunction(userFunctionUri) {
-    return promoteRequestReplyFunction((fn => {
+    return (fn => {
         if (fn.__esModule && typeof fn.default === 'function') {
             // transpiled ES Module interop
             // see https://2ality.com/2017/01/babel-esm-spec-mode.html
             return fn.default;
         }
         return fn;
-    })(require(userFunctionUri)));
+    })(require(userFunctionUri));
 }
 
 const invoke = (userFunction) => {

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -2,6 +2,7 @@ const {Writable} = require('stream');
 const validateArgumentTransformers = require('./argument-transformer-validator');
 const RiffError = require('./riff-error');
 const OutputMarshaller = require('./output-marshaller');
+const promoteRequestReplyFunction = require('./request-reply-promoter');
 const logger = require('util').debuglog('riff');
 const InputUnmarshaller = require('./input-unmarshaller');
 const {guardWithTimeout} = require('./async');
@@ -34,12 +35,13 @@ module.exports = class StreamingPipeline extends Writable {
 
     constructor(userFunction, destinationStream, options) {
         super(options);
-        const arity = userFunction['$arity'];
+        const normalizedUserFunction = promoteRequestReplyFunction(userFunction);
+        const arity = normalizedUserFunction['$arity'];
         validateArity(arity);
-        validateTransformers(userFunction['$argumentTransformers']);
+        validateTransformers(normalizedUserFunction['$argumentTransformers']);
         this._options = options;
         this._hookTimeoutInMs = options['hookTimeoutInMs'] || 10000;
-        this._userFunction = userFunction;
+        this._userFunction = normalizedUserFunction;
         this._destinationStream = destinationStream;
         this._startReceived = false;
         this._functionInputs = [];

--- a/spec/helpers/transformers/invalid-argument-transformer-count-streaming-function.js
+++ b/spec/helpers/transformers/invalid-argument-transformer-count-streaming-function.js
@@ -3,6 +3,7 @@ module.exports = (inputStreams, outputStreams) => {
     inputStreams["0"].pipe(output);
     inputStreams["1"].pipe(output);
 };
+module.exports.$interactionModel = 'node-streams';
 module.exports.$arity = 3;
 module.exports.$argumentTransformers = [
     (x) => x.payload

--- a/spec/streaming-pipeline.errors.spec.js
+++ b/spec/streaming-pipeline.errors.spec.js
@@ -28,6 +28,7 @@ describe('streaming pipeline =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
             inputStreams["0"].pipe(outputStreams["0"]);
         };
+        userFunction.$interactionModel = 'node-streams';
 
         it('fails to instantiate', () => {
             try {
@@ -45,6 +46,7 @@ describe('streaming pipeline =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
             inputStreams["0"].pipe(outputStreams["0"]);
         };
+        userFunction.$interactionModel = 'node-streams';
         userFunction.$arity = 0;
 
         it('fails to instantiate', () => {
@@ -63,6 +65,7 @@ describe('streaming pipeline =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
             inputStreams["0"].pipe(outputStreams["0"]);
         };
+        userFunction.$interactionModel = 'node-streams';
         userFunction.$arity = 1.5;
 
         it('fails to instantiate', () => {
@@ -81,6 +84,7 @@ describe('streaming pipeline =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
             inputStreams["0"].pipe(outputStreams["0"]);
         };
+        userFunction.$interactionModel = 'node-streams';
         userFunction.$arity = 'hello';
 
         it('fails to instantiate', () => {
@@ -296,6 +300,7 @@ describe('streaming pipeline =>', () => {
                 throw new Error('Function failed')
             })).pipe(outputStream);
         };
+        userFunction.$interactionModel = 'node-streams';
         userFunction.$arity = 2;
 
         beforeEach(() => {
@@ -332,6 +337,7 @@ describe('streaming pipeline =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
             inputStreams["0"].pipe(new SimpleTransform({objectMode: true}, (x) => Symbol(x))).pipe(outputStreams["0"]);
         };
+        userFunction.$interactionModel = 'node-streams';
         userFunction.$arity = 2;
 
         beforeEach(() => {

--- a/spec/streaming-pipeline.spec.js
+++ b/spec/streaming-pipeline.spec.js
@@ -32,6 +32,7 @@ describe('streaming pipeline =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
             inputStreams["0"].pipe(newMappingTransform((arg) => arg + 42)).pipe(outputStreams["0"]);
         };
+        userFunction.$interactionModel = 'node-streams';
         userFunction.$arity = 2;
 
         beforeEach(() => {
@@ -89,6 +90,7 @@ describe('streaming pipeline =>', () => {
                         inputEnded = true;
                     })
                 };
+                userFunction.$interactionModel = 'node-streams';
                 userFunction.$arity = 1;
                 streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
                 streamingPipeline.on('finish', () => {
@@ -116,6 +118,7 @@ describe('streaming pipeline =>', () => {
                     outputStream1.end();
                     inputStream.pipe(outputStream2);
                 };
+                userFunction.$interactionModel = 'node-streams';
                 userFunction.$arity = 3;
 
                 let receivedOutputSignalCount = 0;


### PR DESCRIPTION
If the function is promoted too early (i.e. before the gRPC
incoming stream is wired), its streams will be initialized only
once and will not be reusable after the request-reply invocation
(a request-reply invocation = 1 START + 1 NEXT + complete signal).

The promotion is now moved inside the streaming pipeline init,
which occurs every time a new gRPC stream comes in.