### PR TITLE
StreamingPipeline expects "node-streams" functions

### DIFF
--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -2,6 +2,7 @@ const StreamingPipeline = require('./streaming-pipeline');
 const services = require('../codegen/proto/riff-rpc_grpc_pb');
 const logger = require('util').debuglog('riff');
 const grpc = require('grpc');
+const promoteRequestReplyFunction = require('./request-reply-promoter');
 
 function lookUpFunction(userFunctionUri) {
     return (fn => {
@@ -17,7 +18,8 @@ function lookUpFunction(userFunctionUri) {
 const invoke = (userFunction) => {
     return (call) => {
         logger('New invocation started');
-        const pipeline = new StreamingPipeline(userFunction, call, {objectMode: true});
+        const normalizedUserFunction = promoteRequestReplyFunction(userFunction);
+        const pipeline = new StreamingPipeline(normalizedUserFunction, call, { objectMode: true });
         call.pipe(pipeline);
     };
 };

--- a/lib/request-reply-promoter.js
+++ b/lib/request-reply-promoter.js
@@ -56,6 +56,7 @@ module.exports = (userFunction) => {
             .pipe(outputs["0"]);
     };
     promotedFunction.$arity = 2;
+    promotedFunction.$interactionModel = 'node-streams';
     return withTransformers(
         withHooks(promotedFunction, userFunction),
         userFunction

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -2,7 +2,6 @@ const {Writable} = require('stream');
 const validateArgumentTransformers = require('./argument-transformer-validator');
 const RiffError = require('./riff-error');
 const OutputMarshaller = require('./output-marshaller');
-const promoteRequestReplyFunction = require('./request-reply-promoter');
 const logger = require('util').debuglog('riff');
 const InputUnmarshaller = require('./input-unmarshaller');
 const {guardWithTimeout} = require('./async');
@@ -35,13 +34,16 @@ module.exports = class StreamingPipeline extends Writable {
 
     constructor(userFunction, destinationStream, options) {
         super(options);
-        const normalizedUserFunction = promoteRequestReplyFunction(userFunction);
-        const arity = normalizedUserFunction['$arity'];
+        if(userFunction.$interactionModel !== 'node-streams') {
+            throw new Error(`SteamingPipeline expects a function with "node-streams" interaction model, but was "${userFunction.$interactionModel}" instead`);
+        }
+
+        const arity = userFunction['$arity'];
         validateArity(arity);
-        validateTransformers(normalizedUserFunction['$argumentTransformers']);
+        validateTransformers(userFunction['$argumentTransformers']);
         this._options = options;
         this._hookTimeoutInMs = options['hookTimeoutInMs'] || 10000;
-        this._userFunction = normalizedUserFunction;
+        this._userFunction = userFunction;
         this._destinationStream = destinationStream;
         this._startReceived = false;
         this._functionInputs = [];

--- a/spec/helpers/hooks/failing-destroy-hook-streaming-function.js
+++ b/spec/helpers/hooks/failing-destroy-hook-streaming-function.js
@@ -2,6 +2,7 @@ module.exports = (inputStreams, outputStreams) => {
     inputStreams["0"].pipe(outputStreams["0"]);
 };
 module.exports.$arity = 2;
+module.exports.$interactionModel = 'node-streams';
 
 module.exports.$destroy = async () => {
     return new Promise(() => {

--- a/spec/helpers/hooks/failing-init-hook-streaming-function.js
+++ b/spec/helpers/hooks/failing-init-hook-streaming-function.js
@@ -2,6 +2,7 @@ module.exports = (inputStreams, outputStreams) => {
     inputStreams["0"].pipe(outputStreams["0"]);
 };
 module.exports.$arity = 2;
+module.exports.$interactionModel = 'node-streams';
 
 module.exports.$init = async () => {
     return new Promise(() => {

--- a/spec/helpers/hooks/simple-lifecycle-streaming-function.js
+++ b/spec/helpers/hooks/simple-lifecycle-streaming-function.js
@@ -8,6 +8,7 @@ module.exports = (inputStreams, outputStreams) => {
     }, {objectMode: true})).pipe(outputStreams["0"]);
 };
 module.exports.$arity = 2;
+module.exports.$interactionModel = 'node-streams';
 
 module.exports.$init = () => {
     counter = 0;

--- a/spec/helpers/hooks/slow-destroy-hook-streaming-function.js
+++ b/spec/helpers/hooks/slow-destroy-hook-streaming-function.js
@@ -2,6 +2,7 @@ module.exports = (inputStreams, outputStreams) => {
     inputStreams["0"].pipe(outputStreams["0"]);
 };
 module.exports.$arity = 2;
+module.exports.$interactionModel = 'node-streams';
 
 module.exports.$destroy = async () => {
     return new Promise(resolve => {

--- a/spec/helpers/hooks/slow-init-hook-streaming-function.js
+++ b/spec/helpers/hooks/slow-init-hook-streaming-function.js
@@ -2,6 +2,7 @@ module.exports = (inputStreams, outputStreams) => {
     inputStreams["0"].pipe(outputStreams["0"]);
 };
 module.exports.$arity = 2;
+module.exports.$interactionModel = 'node-streams';
 
 module.exports.$init = async () => {
     return new Promise(resolve => {

--- a/spec/helpers/transformers/invalid-argument-transformer-streaming-function.js
+++ b/spec/helpers/transformers/invalid-argument-transformer-streaming-function.js
@@ -4,6 +4,7 @@ module.exports = (inputStreams, outputStreams) => {
     inputStreams["1"].pipe(output);
 };
 module.exports.$arity = 3;
+module.exports.$interactionModel = 'node-streams';
 module.exports.$argumentTransformers = [
     (msg) => msg.payload + "_something",
     42

--- a/spec/helpers/transformers/invalid-argument-transformers-streaming-function.js
+++ b/spec/helpers/transformers/invalid-argument-transformers-streaming-function.js
@@ -4,4 +4,5 @@ module.exports = (inputStreams, outputStreams) => {
     inputStreams["1"].pipe(output);
 };
 module.exports.$arity = 3;
+module.exports.$interactionModel = 'node-streams';
 module.exports.$argumentTransformers = "nope";

--- a/spec/helpers/transformers/wrong-arity-argument-transformers-streaming-function.js
+++ b/spec/helpers/transformers/wrong-arity-argument-transformers-streaming-function.js
@@ -4,6 +4,7 @@ module.exports = (inputStreams, outputStreams) => {
     inputStreams["1"].pipe(output);
 };
 module.exports.$arity = 3;
+module.exports.$interactionModel = 'node-streams';
 module.exports.$argumentTransformers = [
     (msg) => msg,
     () => "constant"

--- a/spec/streaming-pipeline.errors.spec.js
+++ b/spec/streaming-pipeline.errors.spec.js
@@ -106,6 +106,7 @@ describe('streaming pipeline =>', () => {
             inputStream.pipe(newMappingTransform((arg) => arg + 42)).pipe(outputStream);
         };
         userFunction.$arity = 2;
+        userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
             streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
@@ -232,6 +233,7 @@ describe('streaming pipeline =>', () => {
             null.nope();
         };
         userFunction.$arity = 2;
+        userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
             streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
@@ -265,6 +267,7 @@ describe('streaming pipeline =>', () => {
             inputStreams["0"].pipe(outputStreams["0"]);
         };
         userFunction.$arity = 2;
+        userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
             streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
@@ -431,6 +434,16 @@ describe('streaming pipeline =>', () => {
                 done();
             });
             fixedSource.pipe(streamingPipeline);
+        })
+    });
+
+    describe('with a request-reply function', () => {
+        it('throws an error when constructing', () => {
+            const userFunction = () => 42;
+            userFunction.$interactionModel = "request-reply";
+            userFunction.$arity = 1;
+            const construct = () => new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            expect(construct).toThrow(new Error(`SteamingPipeline expects a function with "node-streams" interaction model, but was "request-reply" instead`));
         })
     });
 });


### PR DESCRIPTION
Fixes #106 

- Extract request-reply function promotion outside of StreamingPipeline
- Mark promoted functions as `$interactionModel = "node-streams"`
- Throw when trying to build a StreamPipeline with non node-stream
  functions. This might be a bit hardcore, but, according to the spec,

  `The interaction mode and the arity are required in this case.`