### PR TITLE
Stop writing to pipeline when it errored

### DIFF
--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -20,6 +20,10 @@ const invoke = (userFunction) => {
         logger('New invocation started');
         const normalizedUserFunction = promoteRequestReplyFunction(userFunction);
         const pipeline = new StreamingPipeline(normalizedUserFunction, call, { objectMode: true });
+        pipeline.on('error', () => {
+            logger('Pipeline errored - emitting end of gRPC source stream now');
+            call.emit('end');
+        });
         call.pipe(pipeline);
     };
 };

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -159,7 +159,7 @@ module.exports = class StreamingPipeline extends Writable {
         for (let i = 0; i < inputCount; i++) {
             const inputUnmarshaller = new InputUnmarshaller(this._options, transformers[i]);
             inputUnmarshaller.on('error', (err) => {
-                logger('error from unmarshaller');
+                logger('Error from unmarshaller');
                 this.emit('error', err);
             });
             this._functionInputs[i] = inputUnmarshaller;

--- a/spec/invoker.e2e.spec.js
+++ b/spec/invoker.e2e.spec.js
@@ -151,6 +151,33 @@ describe('invoker =>', () => {
 
         });
     });
+
+    describe('with an input that cannot be unmarshalled =>', () => {
+
+        beforeEach(() => {
+            ({server, address} = tryStartInvoker('../spec/helpers/functions/streaming-square.js'));
+            client = newClient(address);
+        });
+
+        it('ends the source stream', (done) => {
+            const inputs = [
+                newStartSignal(newStartFrame(['application/json'])),
+                newInputSignal(newInputFrame(0, 'text/zglorbf', textEncoder.encode('2'))),
+                newInputSignal(newInputFrame(0, 'application/json', textEncoder.encode('4'))),
+            ];
+
+            const call = client.invoke();
+            call.on('data', () => {
+                done(new Error('no data expected'));
+            });
+            call.on('end', () => {
+                done();
+            });
+            inputs.forEach((input) => {
+                call.write(input);
+            });
+        })
+    });
 });
 
 const tryStartInvoker = (functionUri) => {


### PR DESCRIPTION
Watch error events from the pipeline and stop the gRPC source stream
when that happens.

Fixes #108