### PR TITLE
Fix #130,#131. Improve pipeline error handling and related tests

### DIFF
--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -170,7 +170,7 @@ module.exports = class StreamingPipeline extends Writable {
                 .catch(emitErrorOnReject);
         }
         if (typeof this._userFunction['$destroy'] === 'function') {
-            this._destinationStream.on('finish', () => {
+            this._destinationStream.on('close', () => {
                 logger(`Calling $destroy hook with a max timeout of ${this._hookTimeoutInMs}ms `);
                 guardWithTimeout(this._userFunction.$destroy, this._hookTimeoutInMs)
                     .then(hookResolve('$destroy'))

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -20,10 +20,39 @@ const validateTransformers = (transformers) => {
     validateArgumentTransformers(transformers);
 };
 
+/*
+ * The streaming pipeline is a Writable stream and is expected to be piped to, from a Readable "source" stream of
+ * input signals.
+ *
+ * It sets up the creates the corresponding streaming user function's input and output streams and invokes the user
+ * function upon start signal reception.
+ *
+ * It forwards input signals from the "source" to the matching input stream.
+ * It forwards output signals from the output streams to the destination stream.
+ * The user function is a black box that is given two arguments: the input streams and the output streams.
+ *
+ * <pre>
+ *          |
+ *          |
+ *          |             |->(input 1)-|                      |-> (output 1) -|
+ * (source)--->(pipeline)-|->(input 2)-|-?->(user function)-?-|-> (output 2) -|->(destination)
+ *          |             | ...       -|                      | ...          -|
+ *          |             |->(input n)-|                      |-> (output m) -|
+ *          |
+ * </pre>
+ *
+ * The pipeline closes itself after the last input stream ends.
+ * The destination is closed by the pipeline after the last output stream ends.
+ *
+ * References:
+ *  - ./lib/riff-rpc.proto
+ *  - https://github.com/projectriff/invoker-specification/
+ *  - https://nodejs.org/docs/latest/api/stream.html
+ */
 module.exports = class StreamingPipeline extends Writable {
 
     constructor(userFunction, destinationStream, options) {
-        super(options);
+        super(Object.assign(options, {autoDestroy: true})); // automatically closes upon error
         if (userFunction.$interactionModel !== 'node-streams') {
             throw new Error(`SteamingPipeline expects a function with "node-streams" interaction model, but was "${userFunction.$interactionModel}" instead`);
         }
@@ -33,50 +62,24 @@ module.exports = class StreamingPipeline extends Writable {
         this._hookTimeoutInMs = options['hookTimeoutInMs'] || 10000;
         this._userFunction = userFunction;
         this._destinationStream = destinationStream;
-        this._startReceived = false;
+        this._startProcessed = false;
         this._functionInputs = [];
+        this._finishedInputs = 0;
         this._functionOutputs = [];
         this._finishedOutputs = 0;
         this._streamMetadata = {};
-        this.on('finish', () => {
-            logger('Ending input streams');
+        this._errored = false;
+        this.on('error', () => {
+            this._errored = true;
             this._endInputs();
         });
-        this.on('error', () => {
-            logger('Error occurred - ending pipeline now');
-            this.end();
+        this.on('finish', () => {
+            if (!this._errored) {
+                this._endInputs();
+            }
         });
         this._invokeHooks();
         logger('Streaming pipeline initialized');
-    }
-
-    _invokeHooks() {
-        const hookResolve = (hookName) => {
-            return () => {
-                logger(`${hookName} hook called`)
-            }
-        };
-        const emitErrorOnReject = (err) => {
-            this.emit('error', err)
-        };
-        if (typeof this._userFunction['$init'] === 'function') {
-            logger(`Calling $init hook with a max timeout of ${this._hookTimeoutInMs}ms `);
-            guardWithTimeout(this._userFunction.$init, this._hookTimeoutInMs)
-                .then(hookResolve('$init'))
-                .catch(emitErrorOnReject);
-        }
-        if (typeof this._userFunction['$destroy'] === 'function') {
-            this._destinationStream.on('finish', () => {
-                logger(`Calling $destroy hook with a max timeout of ${this._hookTimeoutInMs}ms `);
-                guardWithTimeout(this._userFunction.$destroy, this._hookTimeoutInMs)
-                    .then(hookResolve('$destroy'))
-                    .catch(emitErrorOnReject);
-            });
-        }
-    }
-
-    _endInputs() {
-        this._functionInputs.forEach((fi) => fi.emit('end'));
     }
 
     _write(inputSignal, _, callback) {
@@ -99,14 +102,13 @@ module.exports = class StreamingPipeline extends Writable {
             const outputContentTypes = startSignal.getExpectedcontenttypesList();
             const inputStreamNames = startSignal.getInputnamesList();
             const outputStreamNames = startSignal.getOutputnamesList();
-            if (this._startReceived) {
+            if (this._startProcessed) {
                 callback(new RiffError(
                     'error-streaming-too-many-starts',
                     'start signal has already been received. ' +
                     `Rejecting start signal with: output content types: [${outputContentTypes}], ` +
                     `input names: [${inputStreamNames}], ` +
                     `output names: [${outputStreamNames}]`));
-
                 return;
             }
             this._streamMetadata.inputs = inputStreamNames;
@@ -136,10 +138,10 @@ module.exports = class StreamingPipeline extends Writable {
             this._wireInputs(transformers);
             this._wireOutputs(outputContentTypes);
             this._invoke(callback);
-            this._startReceived = true;
+            this._startProcessed = true;
             logger('Ready to process data');
         } else {
-            if (!this._startReceived) {
+            if (!this._startProcessed) {
                 callback(new RiffError(
                     'error-streaming-missing-start',
                     'start signal has not been received or processed yet. Rejecting data signal'));
@@ -152,29 +154,80 @@ module.exports = class StreamingPipeline extends Writable {
         }
     }
 
+    _invokeHooks() {
+        const hookResolve = (hookName) => {
+            return () => {
+                logger(`${hookName} hook called`)
+            }
+        };
+        const emitErrorOnReject = (err) => {
+            this.emit('error', err)
+        };
+        if (typeof this._userFunction['$init'] === 'function') {
+            logger(`Calling $init hook with a max timeout of ${this._hookTimeoutInMs}ms `);
+            guardWithTimeout(this._userFunction.$init, this._hookTimeoutInMs)
+                .then(hookResolve('$init'))
+                .catch(emitErrorOnReject);
+        }
+        if (typeof this._userFunction['$destroy'] === 'function') {
+            this._destinationStream.on('finish', () => {
+                logger(`Calling $destroy hook with a max timeout of ${this._hookTimeoutInMs}ms `);
+                guardWithTimeout(this._userFunction.$destroy, this._hookTimeoutInMs)
+                    .then(hookResolve('$destroy'))
+                    .catch(emitErrorOnReject);
+            });
+        }
+    }
+
+    /*
+     * Instantiate n input unmarshallers (where n := number of function input streams).
+     * They are the user function input streams.
+     *
+     * The streaming pipeline ends itself when the last unmarshaller ends.
+     */
     _wireInputs(transformers) {
         const inputCount = transformers.length;
         logger(`Wiring ${inputCount} input stream(s)`);
         for (let i = 0; i < inputCount; i++) {
-            const inputUnmarshaller = new InputUnmarshaller(this._options, transformers[i]);
-            inputUnmarshaller.on('error', (err) => {
+            const unmarshaller = new InputUnmarshaller(this._options, transformers[i]);
+            unmarshaller.on('error', (err) => {
                 logger(`error from unmarshaller: ${err.toString()}`);
                 this.emit('error', err);
             });
-            this._functionInputs[i] = inputUnmarshaller;
+            // TODO: revisit why this is still needed
+            unmarshaller.on('end', () => {
+                this._finishedInputs++;
+                if (this._finishedInputs === this._functionInputs.length) {
+                    logger('Last input stream closing: ending pipeline now');
+                    this._functionInputs = [];
+                    this.end();
+                }
+            });
+            this._functionInputs[i] = unmarshaller;
         }
     }
 
+    /*
+     * Instantiate m output unmarshallers (where m := number of function output streams).
+     * They are the function output streams.
+     *
+     * The destination stream is ended when the last unmarshaller ends.
+     */
     _wireOutputs(outputContentTypes) {
         const outputCount = outputContentTypes.length;
         logger(`Wiring ${outputCount} output stream(s)`);
         for (let i = 0; i < outputCount; i++) {
             const marshaller = new OutputMarshaller(i, outputContentTypes[i], this._options);
             marshaller.pipe(this._destinationStream, {end: false});
+            marshaller.on('error', (err) => {
+                logger(`error from marshaller: ${err.toString()}`);
+                this.emit('error', err);
+            });
             marshaller.on('finish', () => {
                 this._finishedOutputs++;
                 if (this._finishedOutputs === this._functionOutputs.length) {
                     logger('Last output stream closing: ending destination stream');
+                    this._functionOutputs = [];
                     this._destinationStream.end();
                 }
             });
@@ -191,5 +244,9 @@ module.exports = class StreamingPipeline extends Writable {
         } catch (err) {
             callback(new RiffError('streaming-function-runtime-error', err));
         }
+    }
+
+    _endInputs() {
+        this._functionInputs.forEach((fi) => fi.emit('end'));
     }
 };

--- a/spec/streaming-pipeline.errors.spec.js
+++ b/spec/streaming-pipeline.errors.spec.js
@@ -47,14 +47,17 @@ describe('streaming pipeline =>', () => {
             });
 
             it('emits an error', (done) => {
-                streamingPipeline.on('error', (err) => {
+                let errored = false;
+                streamingPipeline.prependListener('error', (err) => {
                     expect(err.type).toEqual('error-streaming-input-invalid');
                     expect(err.cause).toEqual('invalid input type [object String]');
+                    errored = true;
                 });
-                streamingPipeline.on('finish', () => {
+                streamingPipeline.on('close', () => {
+                    expect(errored).toBeTruthy('pipeline should have errored');
                     done();
                 });
-                fixedSource.pipe(streamingPipeline);
+                fixedSource.pipe(streamingPipeline, {end: false});
             });
         });
 
@@ -64,14 +67,17 @@ describe('streaming pipeline =>', () => {
             });
 
             it('emits an error', (done) => {
-                streamingPipeline.on('error', (err) => {
+                let errored = false;
+                streamingPipeline.prependListener('error', (err) => {
                     expect(err.type).toEqual('error-streaming-input-invalid');
                     expect(err.cause).toEqual('input is neither a start nor a data signal');
+                    errored = true;
                 });
-                streamingPipeline.on('finish', () => {
+                streamingPipeline.on('close', () => {
+                    expect(errored).toBeTruthy('pipeline should have errored');
                     done();
                 });
-                fixedSource.pipe(streamingPipeline);
+                fixedSource.pipe(streamingPipeline, {end: false});
             });
         });
 
@@ -87,7 +93,8 @@ describe('streaming pipeline =>', () => {
                 destinationStream.on('data', () => {
                     done(new Error('should not receive any data'));
                 });
-                streamingPipeline.on('error', (err) => {
+                let errored = false;
+                streamingPipeline.prependListener('error', (err) => {
                     expect(err.type).toEqual('error-streaming-too-many-starts');
                     expect(err.cause).toEqual(
                         'start signal has already been received. ' +
@@ -96,11 +103,13 @@ describe('streaming pipeline =>', () => {
                         'input names: [input], ' +
                         'output names: [output]'
                     );
+                    errored = true;
                 });
-                streamingPipeline.on('finish', () => {
+                streamingPipeline.on('close', () => {
+                    expect(errored).toBeTruthy('pipeline should have errored');
                     done();
                 });
-                fixedSource.pipe(streamingPipeline);
+                fixedSource.pipe(streamingPipeline, {end: false});
             })
         });
 
@@ -116,16 +125,19 @@ describe('streaming pipeline =>', () => {
                 destinationStream.on('data', () => {
                     done(new Error('should not receive any data'));
                 });
-                streamingPipeline.on('error', (err) => {
+                let errored = false;
+                streamingPipeline.prependListener('error', (err) => {
                     expect(err.type).toEqual('error-streaming-invalid-output-count');
                     expect(err.cause).toEqual(
                         'invalid output count 3: function has only 1 output(s)'
                     );
+                    errored = true;
                 });
-                streamingPipeline.on('finish', () => {
+                streamingPipeline.on('close', () => {
+                    expect(errored).toBeTruthy('pipeline should have errored');
                     done();
                 });
-                fixedSource.pipe(streamingPipeline);
+                fixedSource.pipe(streamingPipeline, {end: false});
             })
         });
 
@@ -140,17 +152,20 @@ describe('streaming pipeline =>', () => {
                 destinationStream.on('data', () => {
                     done(new Error('should not receive any data'));
                 });
-                streamingPipeline.on('error', (err) => {
+                let errored = false;
+                streamingPipeline.prependListener('error', (err) => {
                     expect(err.type).toEqual('error-streaming-missing-start');
                     expect(err.cause).toEqual(
                         'start signal has not been received or processed yet. ' +
                         'Rejecting data signal'
                     );
+                    errored = true;
                 });
-                streamingPipeline.on('finish', () => {
+                streamingPipeline.on('close', () => {
+                    expect(errored).toBeTruthy('pipeline should have errored');
                     done();
                 });
-                fixedSource.pipe(streamingPipeline);
+                fixedSource.pipe(streamingPipeline, {end: false});
             })
         });
     });
@@ -178,14 +193,17 @@ describe('streaming pipeline =>', () => {
             destinationStream.on('data', () => {
                 done(new Error('should not receive any data'));
             });
-            streamingPipeline.on('error', (err) => {
+            let errored = false;
+            streamingPipeline.prependListener('error', (err) => {
                 expect(err.type).toEqual('streaming-function-runtime-error');
                 expect(err.cause.message).toEqual(`Cannot read property 'nope' of null`);
+                errored = true;
             });
-            streamingPipeline.on('finish', () => {
+            streamingPipeline.on('close', () => {
+                expect(errored).toBeTruthy('pipeline should have errored');
                 done();
             });
-            fixedSource.pipe(streamingPipeline);
+            fixedSource.pipe(streamingPipeline, {end: false});
         })
     });
 
@@ -208,16 +226,16 @@ describe('streaming pipeline =>', () => {
                 done(new Error('should not receive any data'));
             });
             let errored = false;
-            streamingPipeline.on('error', (err) => {
+            streamingPipeline.prependListener('error', (err) => {
                 expect(err.type).toEqual('error-input-invalid');
                 expect(err.cause.message).toEqual('Unexpected token i in JSON at position 0');
                 errored = true;
             });
-            streamingPipeline.on('finish', () => {
+            streamingPipeline.on('close', () => {
                 expect(errored).toBeTruthy('pipeline should have errored');
                 done();
             });
-            fixedSource.pipe(streamingPipeline);
+            fixedSource.pipe(streamingPipeline, {end: false});
         })
     });
 
@@ -247,21 +265,22 @@ describe('streaming pipeline =>', () => {
                 done(new Error('should not receive any data'));
             });
             let errored = false;
-            streamingPipeline.on('error', (err) => {
+            streamingPipeline.prependListener('error', (err) => {
                 expect(err.message).toEqual('Function failed');
                 errored = true;
             });
-            streamingPipeline.on('finish', () => {
+            streamingPipeline.on('close', () => {
                 expect(errored).toBeTruthy('pipeline should have errored');
                 done();
             });
-            fixedSource.pipe(streamingPipeline);
+            fixedSource.pipe(streamingPipeline, {end: false});
         })
     });
 
     describe('with a function producing outputs that cannot be marshalled =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
-            inputStreams.$order[0].pipe(new SimpleTransform({objectMode: true}, (x) => Symbol(x)))
+            inputStreams.$order[0]
+                .pipe(new SimpleTransform({objectMode: true}, (x) => Symbol(x)))
                 .pipe(outputStreams.$order[0]);
         };
         userFunction.$interactionModel = 'node-streams';
@@ -284,16 +303,16 @@ describe('streaming pipeline =>', () => {
                 done(new Error('should not receive any data'));
             });
             let errored = false;
-            streamingPipeline.on('error', (err) => {
+            streamingPipeline.prependListener('error', (err) => {
                 expect(err.type).toEqual('error-output-invalid');
                 expect(err.cause.message).toEqual('Cannot convert a Symbol value to a string');
                 errored = true;
             });
-            streamingPipeline.on('finish', () => {
+            streamingPipeline.on('close', () => {
                 expect(errored).toBeTruthy('pipeline should have errored');
                 done();
             });
-            fixedSource.pipe(streamingPipeline);
+            fixedSource.pipe(streamingPipeline, {end: false});
         })
     });
 
@@ -356,7 +375,7 @@ describe('streaming pipeline =>', () => {
                 expect(err.cause).toEqual('Function must declare exactly 2 argument transformer(s). Found 1');
                 done();
             });
-            fixedSource.pipe(streamingPipeline);
+            fixedSource.pipe(streamingPipeline, {end: false});
         })
     });
 


### PR DESCRIPTION
 1. prepend test error listeners (see explanation below)
 2. observe 'close' events after 'error', not 'finish' (source:
https://github.com/nodejs/help/issues/2412)
 3. make sure pipeline is ended by error handling and not by
propagation of the piped source regular completion ({end: false})
 4. create pipeline stream with autodestroy enabled, so that the
stream automatically closes upon error
 5. reorder and document streaming pipeline class for clarity

When an marshaller's or unmarshaller's error happens, the streaming
pipeline intercepts (`unmarshaller.on('error', ...)`) and emits it
itself (`this.emit('error', ...)`), cleans up input/output streams and
completes (which means: emits a `finish` event).

Given `emit` is completely synchronous, this means that the pipeline's
`finish` listeners will always be executed as part of the synchronous
execution of the pipeline's own `error` handler (which is, by default,
the first pipeline's `error` handler to be executed as it is
registered in the pipeline's constructor).

The error case tests assumed that the test `error` handler will always
be executed before the test `finish` handler.  This can only work if the
test `error` handler is prepended to the list of `error` handler.