### PR TITLE
Cancel grpc invocation when sensible

### DIFF
--- a/lib/argument-transformer-validator.js
+++ b/lib/argument-transformer-validator.js
@@ -1,22 +1,23 @@
 const RiffError = require('./riff-error');
+const {types: errorTypes} = require('./errors');
 
 const validateArgumentTransformer = (argumentTransformer, transformerIndex) => {
     const transformerType = typeof argumentTransformer;
     if (transformerType !== 'function') {
-        throw new RiffError('error-argument-transformer', `Argument transformer #${1 + transformerIndex} must be a function. Found: ${transformerType}`)
+        throw new RiffError(errorTypes.ARGUMENT_TRANSFORMER, `Argument transformer #${1 + transformerIndex} must be a function. Found: ${transformerType}`)
     }
 
     const transformerArity = argumentTransformer.length;
     if (transformerArity !== 1) {
         throw new RiffError(
-            'error-argument-transformer',
+            errorTypes.ARGUMENT_TRANSFORMER,
             `Argument transformer #${1 + transformerIndex} must be a single-parameter function. Found: ${transformerArity} parameter(s)`);
     }
 };
 
 module.exports = (argumentTransformers) => {
     if (!Array.isArray(argumentTransformers)) {
-        throw new RiffError('error-argument-transformer', `Argument transformers must be declared in an array. Found: ${typeof argumentTransformers}`);
+        throw new RiffError(errorTypes.ARGUMENT_TRANSFORMER, `Argument transformers must be declared in an array. Found: ${typeof argumentTransformers}`);
     }
     argumentTransformers.forEach(validateArgumentTransformer);
 };

--- a/lib/async.js
+++ b/lib/async.js
@@ -1,13 +1,14 @@
 const RiffError = require('./riff-error');
+const {types: errorTypes} = require('./errors');
 
 const handleError = (reject) => (err) => {
-    return reject(new RiffError('error-hook-runtime-error', err));
+    return reject(new RiffError(errorTypes.HOOK_RUNTIME, err));
 };
 
 module.exports.guardWithTimeout = (hookFn, timeoutInMs) => {
     return new Promise((resolve, reject) => {
         const timerId = setTimeout(() => {
-            reject(new RiffError('error-hook-timeout', 'The hook took too long to run. Aborting now'));
+            reject(new RiffError(errorTypes.HOOK_TIMEOUT, 'The hook took too long to run. Aborting now'));
         }, timeoutInMs);
 
         try {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,29 @@
+module.exports = {
+    types: {
+        // streaming protocol
+        PROTOCOL_INVALID_INPUT_SIGNAL: 'error-streaming-invalid-input-signal',
+        PROTOCOL_MISSING_START_SIGNAL: 'error-streaming-missing-start-signal',
+        PROTOCOL_OUTPUT_COUNT_MISMATCH: 'error-streaming-invalid-output-count',
+        PROTOCOL_TOO_MANY_START_SIGNALS: 'error-streaming-too-many-start-signals',
+        // streaming functions
+        STREAMING_FUNCTION_RUNTIME: 'streaming-function-runtime-error',
+        // request-reply functions
+        REQUEST_REPLY_FUNCTION_RUNTIME: 'request-reply-function-runtime-error',
+        FUNCTION_PROMOTION: 'error-promoting-function',
+        // argument transformers
+        ARGUMENT_TRANSFORMER: 'error-argument-transformer',
+        // hooks
+        HOOK_TIMEOUT: 'error-hook-timeout',
+        HOOK_RUNTIME: 'error-hook-runtime-error',
+        // (un)marshalling errors
+        UNSUPPORTED_INPUT_CONTENT_TYPE: 'error-input-content-type-unsupported',
+        INVALID_INPUT: 'error-input-invalid',
+        UNSUPPORTED_OUTPUT_CONTENT_TYPE: 'error-output-content-type-unsupported',
+        INVALID_OUTPUT: 'error-output-invalid',
+    },
+    // these are specially handled by the streaming HTTP adapter
+    reserved_prefixes: {
+        NOT_ACCEPTABLE: 'Invoker: Not Acceptable',
+        UNSUPPORTED_MEDIA_TYPE: 'Invoker: Unsupported Media Type'
+    }
+};

--- a/lib/input-unmarshaller.js
+++ b/lib/input-unmarshaller.js
@@ -31,7 +31,7 @@ module.exports = class InputUnmarshaller extends Transform {
         const contentType = dataSignal.getContenttype();
         const acceptedContentType = determineContentTypes(contentType).accept;
         if (!canUnmarshall(acceptedContentType)) {
-            callback(new RiffError('error-input-content-type-unsupported', `unsupported input #${inputIndex}'s content-type ${contentType}`));
+            callback(new RiffError('error-input-content-type-unsupported', `Unsupported content-type '${contentType}' for input #${inputIndex}`));
             return;
         }
 

--- a/lib/input-unmarshaller.js
+++ b/lib/input-unmarshaller.js
@@ -2,6 +2,7 @@ const {Transform} = require('stream');
 const RiffError = require('./riff-error');
 const {Message} = require('@projectriff/message');
 const logger = require('util').debuglog('riff');
+const {types: errorTypes} = require('./errors');
 const {canUnmarshall, determineContentTypes, unmarshaller} = require('./content-negotiation');
 
 const DEFAULT_ARGUMENT_TRANSFORMER = (msg) => msg.payload;
@@ -31,7 +32,7 @@ module.exports = class InputUnmarshaller extends Transform {
         const contentType = dataSignal.getContenttype();
         const acceptedContentType = determineContentTypes(contentType).accept;
         if (!canUnmarshall(acceptedContentType)) {
-            callback(new RiffError('error-input-content-type-unsupported', `Unsupported content-type '${contentType}' for input #${inputIndex}`));
+            callback(new RiffError(errorTypes.UNSUPPORTED_INPUT_CONTENT_TYPE, `Unsupported content-type '${contentType}' for input #${inputIndex}`));
             return;
         }
 
@@ -40,7 +41,7 @@ module.exports = class InputUnmarshaller extends Transform {
             unmarshalledPayload = unmarshaller(acceptedContentType)(rawPayload);
             logger(`Forwarding data for input #${inputIndex}`);
         } catch (err) {
-            callback(new RiffError('error-input-invalid', err));
+            callback(new RiffError(errorTypes.INVALID_INPUT, err));
             return;
         }
 
@@ -49,7 +50,7 @@ module.exports = class InputUnmarshaller extends Transform {
             const message = convertToRiffMessage(unmarshalledPayload, dataSignal.getHeadersMap());
             finalPayload = this.argumentTransformer(message);
         } catch (err) {
-            callback(new RiffError('error-argument-transformer', err));
+            callback(new RiffError(errorTypes.ARGUMENT_TRANSFORMER, err));
             return;
         }
 

--- a/lib/mapping-transform.js
+++ b/lib/mapping-transform.js
@@ -1,5 +1,6 @@
 const {Transform} = require('stream');
 const RiffError = require('./riff-error');
+const {types: errorTypes} = require('./errors');
 
 module.exports = class MappingTransform extends Transform {
 
@@ -29,6 +30,9 @@ module.exports = class MappingTransform extends Transform {
     }
 
     _handleError(err) {
-        this.emit('error', new RiffError('request-reply-function-runtime-error', err));
+        this.emit('error', new RiffError(
+            errorTypes.REQUEST_REPLY_FUNCTION_RUNTIME,
+            err
+        ));
     }
 };

--- a/lib/output-marshaller.js
+++ b/lib/output-marshaller.js
@@ -1,22 +1,15 @@
 const {Transform} = require('stream');
 const logger = require('util').debuglog('riff');
 const RiffError = require('./riff-error');
-const {canMarshall, determineContentTypes, marshaller} = require('./content-negotiation');
+const {marshaller} = require('./content-negotiation');
 const {AbstractMessage, Message} = require('@projectriff/message');
 
 module.exports = class OutputMarshaller extends Transform {
 
     constructor(index, contentType, options) {
         super(options);
-        if (index < 0) {
-            throw new RiffError('error-output-index-invalid', `invalid output index: ${index}`);
-        }
-        const acceptedContentType = determineContentTypes(contentType).accept;
-        if (!canMarshall(acceptedContentType)) {
-            throw new RiffError('error-output-content-type-unsupported', `unrecognized output #${index}'s content-type ${contentType}`);
-        }
         this._index = index;
-        this._acceptedContentType = acceptedContentType;
+        this._acceptedContentType = contentType;
         this._marshallerFunction = marshaller(this._acceptedContentType);
     }
 

--- a/lib/output-marshaller.js
+++ b/lib/output-marshaller.js
@@ -2,6 +2,7 @@ const {Transform} = require('stream');
 const logger = require('util').debuglog('riff');
 const RiffError = require('./riff-error');
 const {marshaller} = require('./content-negotiation');
+const {types: errorTypes} = require('./errors');
 const {AbstractMessage, Message} = require('@projectriff/message');
 
 module.exports = class OutputMarshaller extends Transform {
@@ -19,7 +20,7 @@ module.exports = class OutputMarshaller extends Transform {
         try {
             payload = this._marshallerFunction(message.payload);
         } catch (err) {
-            callback(new RiffError('error-output-invalid', err));
+            callback(new RiffError(errorTypes.INVALID_OUTPUT, err));
             return;
         }
         const outputFrame = new proto.streaming.OutputFrame();

--- a/lib/request-reply-promoter.js
+++ b/lib/request-reply-promoter.js
@@ -2,6 +2,7 @@ const validateArgumentTransformers = require('./argument-transformer-validator')
 const RiffError = require('./riff-error');
 const MappingTransform = require('./mapping-transform');
 const logger = require('util').debuglog('riff');
+const {types: errorTypes} = require('./errors');
 
 const withTransformers = (promotedFunction, userFunction) => {
     const transformers = userFunction['$argumentTransformers'];
@@ -12,7 +13,7 @@ const withTransformers = (promotedFunction, userFunction) => {
     const transformerCount = transformers.length;
     if (transformerCount !== 1) {
         throw new RiffError(
-            'error-argument-transformer',
+            errorTypes.ARGUMENT_TRANSFORMER,
             `Request-reply function must declare exactly 1 argument transformer. Found ${transformerCount}`
         );
     }
@@ -38,7 +39,7 @@ const withHooks = (promotedFunction, userFunction) => {
 const validateHook = (hook, hookName) => {
     const hookType = typeof hook;
     if (hookType !== 'function' && hookType !== 'undefined') {
-        throw new RiffError('error-promoting-function', `Request-reply function ${hookName} hook must be a function. Found: ${hookType}`);
+        throw new RiffError(errorTypes.FUNCTION_PROMOTION, `Request-reply function ${hookName} hook must be a function. Found: ${hookType}`);
     }
 };
 

--- a/lib/riff-error.js
+++ b/lib/riff-error.js
@@ -11,4 +11,9 @@ module.exports = class RiffError extends Error {
         this.type = type;
         this.cause = cause;
     }
+
+
+    toString() {
+        return `${this.type}: ${this.cause}`;
+    }
 };

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -82,6 +82,11 @@ module.exports = class StreamingPipeline extends Writable {
                     `Invoker: Unexpected Invocation Error: ${err.cause.message}`
                 );
                 break;
+            default:
+                grpcStream.call.cancelWithStatus(
+                    grpc.status.UNKNOWN,
+                    `Invoker: Unexpected Error: ${err.cause ? err.cause : err.message ? err.message : err}`
+                );
         }
     }
 

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -5,6 +5,8 @@ const OutputMarshaller = require('./output-marshaller');
 const logger = require('util').debuglog('riff');
 const InputUnmarshaller = require('./input-unmarshaller');
 const {guardWithTimeout} = require('./async');
+const grpc = require('grpc');
+const {canMarshall, determineContentTypes} = require('./content-negotiation');
 
 const toObject = (parameters, streamNames) => {
     return parameters.reduce((result, stream, i) => {
@@ -22,7 +24,7 @@ const validateTransformers = (transformers) => {
 
 module.exports = class StreamingPipeline extends Writable {
 
-    constructor(userFunction, destinationStream, options) {
+    constructor(userFunction, grpcStream, options) {
         super(options);
         if (userFunction.$interactionModel !== 'node-streams') {
             throw new Error(`SteamingPipeline expects a function with "node-streams" interaction model, but was "${userFunction.$interactionModel}" instead`);
@@ -32,7 +34,7 @@ module.exports = class StreamingPipeline extends Writable {
         this._options = options;
         this._hookTimeoutInMs = options['hookTimeoutInMs'] || 10000;
         this._userFunction = userFunction;
-        this._destinationStream = destinationStream;
+        this._destinationStream = grpcStream;
         this._startReceived = false;
         this._functionInputs = [];
         this._functionOutputs = [];
@@ -42,12 +44,44 @@ module.exports = class StreamingPipeline extends Writable {
             logger('Ending input streams');
             this._endInputs();
         });
-        this.on('error', () => {
-            logger('Error occurred - ending pipeline now');
-            this.end();
+        this.on('error', (err) => {
+            logger('Error occurred - canceling invocation now');
+            this._cancelCall(grpcStream, err);
         });
         this._invokeHooks();
         logger('Streaming pipeline initialized');
+    }
+
+    _cancelCall(grpcStream, err) {
+        switch (err.type) {
+            case 'error-streaming-invalid-input-signal':
+            case 'error-streaming-invalid-output-count':
+            case 'error-streaming-missing-start-signal':
+            case 'error-streaming-too-many-start-signals':
+                grpcStream.call.cancelWithStatus(
+                    grpc.status.UNKNOWN,
+                    `Invoker: Protocol Violation: ${err.cause}`
+                );
+                break;
+            case 'error-output-content-type-unsupported':
+                grpcStream.call.cancelWithStatus(
+                    grpc.status.INVALID_ARGUMENT,
+                    `Invoker: Not Acceptable: ${err.cause}`
+                );
+                break;
+            case 'error-input-content-type-unsupported':
+                grpcStream.call.cancelWithStatus(
+                    grpc.status.INVALID_ARGUMENT,
+                    `Invoker: Unsupported Media Type: ${err.cause}`
+                );
+                break;
+            case 'streaming-function-runtime-error':
+                grpcStream.call.cancelWithStatus(
+                    grpc.status.UNKNOWN,
+                    `Invoker: Unexpected Invocation Error: ${err.cause.message}`
+                );
+                break;
+        }
     }
 
     _invokeHooks() {
@@ -83,14 +117,14 @@ module.exports = class StreamingPipeline extends Writable {
         logger('Input signal received');
         if (!inputSignal || !inputSignal['hasStart'] || !inputSignal['hasData']) {
             callback(new RiffError(
-                'error-streaming-input-invalid',
-                `invalid input type ${Object.prototype.toString.call(inputSignal)}`));
+                'error-streaming-invalid-input-signal',
+                `Invalid input signal type ${Object.prototype.toString.call(inputSignal)}`));
             return;
         }
         if (!inputSignal.hasStart() && !inputSignal.hasData()) {
             callback(new RiffError(
-                'error-streaming-input-invalid',
-                'input is neither a start nor a data signal'));
+                'error-streaming-invalid-input-signal',
+                'Input is neither a start nor a data signal'));
             return;
         }
 
@@ -101,8 +135,8 @@ module.exports = class StreamingPipeline extends Writable {
             const outputStreamNames = startSignal.getOutputnamesList();
             if (this._startReceived) {
                 callback(new RiffError(
-                    'error-streaming-too-many-starts',
-                    'start signal has already been received. ' +
+                    'error-streaming-too-many-start-signals',
+                    'Start signal has already been received. ' +
                     `Rejecting start signal with: output content types: [${outputContentTypes}], ` +
                     `input names: [${inputStreamNames}], ` +
                     `output names: [${outputStreamNames}]`));
@@ -116,7 +150,7 @@ module.exports = class StreamingPipeline extends Writable {
             if (actualOutputCount !== expectedOutputCount) {
                 callback(new RiffError(
                     'error-streaming-invalid-output-count',
-                    `invalid output count ${actualOutputCount}: function has only ${expectedOutputCount} output(s)`));
+                    `Invalid output count ${actualOutputCount}: function has only ${expectedOutputCount} output(s)`));
                 return;
             }
             logger(`Start signal with: output content types: ${outputContentTypes}, ` +
@@ -131,18 +165,31 @@ module.exports = class StreamingPipeline extends Writable {
                 callback(new RiffError(
                     'error-argument-transformer',
                     `Function must declare exactly ${inputCount} argument transformer(s). Found ${transformerCount}`));
-                return false;
+                return;
             }
+
+            const negotiatedOutputContentTypes = outputContentTypes.map(ct => determineContentTypes(ct).accept);
+            for (let i = 0; i < negotiatedOutputContentTypes.length; i++) {
+                const contentType = negotiatedOutputContentTypes[i];
+                if (!canMarshall(contentType)) {
+                    logger(`Unsupported content type ${contentType} for output #${i}`);
+                    callback(new RiffError(
+                        'error-output-content-type-unsupported',
+                        `Unsupported content-type '${outputContentTypes[i]}' for output #${i}`));
+                    return;
+                }
+            }
+
             this._wireInputs(transformers);
-            this._wireOutputs(outputContentTypes);
+            this._wireOutputs(negotiatedOutputContentTypes);
             this._invoke(callback);
             this._startReceived = true;
             logger('Ready to process data');
         } else {
             if (!this._startReceived) {
                 callback(new RiffError(
-                    'error-streaming-missing-start',
-                    'start signal has not been received or processed yet. Rejecting data signal'));
+                    'error-streaming-missing-start-signal',
+                    'Start signal has not been received or processed yet. Rejecting data signal'));
                 return;
             }
             const inputIndex = inputSignal.getData().getArgindex();

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -6,6 +6,7 @@ const logger = require('util').debuglog('riff');
 const InputUnmarshaller = require('./input-unmarshaller');
 const {guardWithTimeout} = require('./async');
 const grpc = require('grpc');
+const errors = require('./errors');
 const {canMarshall, determineContentTypes} = require('./content-negotiation');
 
 const toObject = (parameters, streamNames) => {
@@ -54,28 +55,28 @@ module.exports = class StreamingPipeline extends Writable {
 
     _cancelCall(grpcStream, err) {
         switch (err.type) {
-            case 'error-streaming-invalid-input-signal':
-            case 'error-streaming-invalid-output-count':
-            case 'error-streaming-missing-start-signal':
-            case 'error-streaming-too-many-start-signals':
+            case errors.types.PROTOCOL_INVALID_INPUT_SIGNAL:
+            case errors.types.PROTOCOL_OUTPUT_COUNT_MISMATCH:
+            case errors.types.PROTOCOL_MISSING_START_SIGNAL:
+            case errors.types.PROTOCOL_TOO_MANY_START_SIGNALS:
                 grpcStream.call.cancelWithStatus(
                     grpc.status.UNKNOWN,
                     `Invoker: Protocol Violation: ${err.cause}`
                 );
                 break;
-            case 'error-output-content-type-unsupported':
+            case errors.types.UNSUPPORTED_OUTPUT_CONTENT_TYPE:
                 grpcStream.call.cancelWithStatus(
                     grpc.status.INVALID_ARGUMENT,
-                    `Invoker: Not Acceptable: ${err.cause}`
+                    `${errors.reserved_prefixes.NOT_ACCEPTABLE}: ${err.cause}`
                 );
                 break;
-            case 'error-input-content-type-unsupported':
+            case errors.types.UNSUPPORTED_INPUT_CONTENT_TYPE:
                 grpcStream.call.cancelWithStatus(
                     grpc.status.INVALID_ARGUMENT,
-                    `Invoker: Unsupported Media Type: ${err.cause}`
+                    `${errors.reserved_prefixes.UNSUPPORTED_MEDIA_TYPE}: ${err.cause}`
                 );
                 break;
-            case 'streaming-function-runtime-error':
+            case errors.types.STREAMING_FUNCTION_RUNTIME:
                 grpcStream.call.cancelWithStatus(
                     grpc.status.UNKNOWN,
                     `Invoker: Unexpected Invocation Error: ${err.cause.message}`
@@ -117,13 +118,13 @@ module.exports = class StreamingPipeline extends Writable {
         logger('Input signal received');
         if (!inputSignal || !inputSignal['hasStart'] || !inputSignal['hasData']) {
             callback(new RiffError(
-                'error-streaming-invalid-input-signal',
+                errors.types.PROTOCOL_INVALID_INPUT_SIGNAL,
                 `Invalid input signal type ${Object.prototype.toString.call(inputSignal)}`));
             return;
         }
         if (!inputSignal.hasStart() && !inputSignal.hasData()) {
             callback(new RiffError(
-                'error-streaming-invalid-input-signal',
+                errors.types.PROTOCOL_INVALID_INPUT_SIGNAL,
                 'Input is neither a start nor a data signal'));
             return;
         }
@@ -135,7 +136,7 @@ module.exports = class StreamingPipeline extends Writable {
             const outputStreamNames = startSignal.getOutputnamesList();
             if (this._startReceived) {
                 callback(new RiffError(
-                    'error-streaming-too-many-start-signals',
+                    errors.types.PROTOCOL_TOO_MANY_START_SIGNALS,
                     'Start signal has already been received. ' +
                     `Rejecting start signal with: output content types: [${outputContentTypes}], ` +
                     `input names: [${inputStreamNames}], ` +
@@ -149,7 +150,7 @@ module.exports = class StreamingPipeline extends Writable {
             const expectedOutputCount = this._streamMetadata.outputs.length;
             if (actualOutputCount !== expectedOutputCount) {
                 callback(new RiffError(
-                    'error-streaming-invalid-output-count',
+                    errors.types.PROTOCOL_OUTPUT_COUNT_MISMATCH,
                     `Invalid output count ${actualOutputCount}: function has only ${expectedOutputCount} output(s)`));
                 return;
             }
@@ -163,7 +164,7 @@ module.exports = class StreamingPipeline extends Writable {
                 const transformerCount = transformers.length;
                 logger(`Wrong number of argument transformers: ${transformerCount} instead of ${inputCount}`);
                 callback(new RiffError(
-                    'error-argument-transformer',
+                    errors.types.ARGUMENT_TRANSFORMER,
                     `Function must declare exactly ${inputCount} argument transformer(s). Found ${transformerCount}`));
                 return;
             }
@@ -174,7 +175,7 @@ module.exports = class StreamingPipeline extends Writable {
                 if (!canMarshall(contentType)) {
                     logger(`Unsupported content type ${contentType} for output #${i}`);
                     callback(new RiffError(
-                        'error-output-content-type-unsupported',
+                        errors.types.UNSUPPORTED_OUTPUT_CONTENT_TYPE,
                         `Unsupported content-type '${outputContentTypes[i]}' for output #${i}`));
                     return;
                 }
@@ -188,7 +189,7 @@ module.exports = class StreamingPipeline extends Writable {
         } else {
             if (!this._startReceived) {
                 callback(new RiffError(
-                    'error-streaming-missing-start-signal',
+                    errors.types.PROTOCOL_MISSING_START_SIGNAL,
                     'Start signal has not been received or processed yet. Rejecting data signal'));
                 return;
             }
@@ -236,7 +237,7 @@ module.exports = class StreamingPipeline extends Writable {
             this._userFunction.apply(null, [inputStreams, outputStreams]);
             callback();
         } catch (err) {
-            callback(new RiffError('streaming-function-runtime-error', err));
+            callback(new RiffError(errors.types.STREAMING_FUNCTION_RUNTIME, err));
         }
     }
 };

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -174,17 +174,18 @@ module.exports = class StreamingPipeline extends Writable {
                 return;
             }
 
-            const normalizedOutputContentTypes = outputContentTypes
-                .map((initialContentType) => determineContentTypes(initialContentType).accept);
-            const unsupportedContentTypeIndex = normalizedOutputContentTypes
-                .findIndex((contentType) => !canMarshall(contentType));
-            if (unsupportedContentTypeIndex >= 0) {
-                const contentType = outputContentTypes[unsupportedContentTypeIndex];
-                logger(`Unsupported content type ${contentType} for output #${unsupportedContentTypeIndex}`);
-                callback(new RiffError(
-                    errors.types.UNSUPPORTED_OUTPUT_CONTENT_TYPE,
-                    `Unsupported content-type '${contentType}' for output #${unsupportedContentTypeIndex}`));
-                return;
+            const normalizedOutputContentTypes = [];
+            for (let i = 0; i < outputContentTypes.length; i++) {
+                const contentType = outputContentTypes[i];
+                const normalizedOutputContentType = determineContentTypes(contentType).accept;
+                if (!canMarshall(normalizedOutputContentType)) {
+                    logger(`Unsupported content type ${contentType} for output #${i}`);
+                    callback(new RiffError(
+                        errors.types.UNSUPPORTED_OUTPUT_CONTENT_TYPE,
+                        `Unsupported content-type '${contentType}' for output #${i}`));
+                    return;
+                }
+                normalizedOutputContentTypes.push(normalizedOutputContentType);
             }
 
             this._wireInputs(transformers);

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -174,20 +174,21 @@ module.exports = class StreamingPipeline extends Writable {
                 return;
             }
 
-            const negotiatedOutputContentTypes = outputContentTypes.map(ct => determineContentTypes(ct).accept);
-            for (let i = 0; i < negotiatedOutputContentTypes.length; i++) {
-                const contentType = negotiatedOutputContentTypes[i];
-                if (!canMarshall(contentType)) {
-                    logger(`Unsupported content type ${contentType} for output #${i}`);
-                    callback(new RiffError(
-                        errors.types.UNSUPPORTED_OUTPUT_CONTENT_TYPE,
-                        `Unsupported content-type '${outputContentTypes[i]}' for output #${i}`));
-                    return;
-                }
+            const normalizedOutputContentTypes = outputContentTypes
+                .map((initialContentType) => determineContentTypes(initialContentType).accept);
+            const unsupportedContentTypeIndex = normalizedOutputContentTypes
+                .findIndex((contentType) => !canMarshall(contentType));
+            if (unsupportedContentTypeIndex >= 0) {
+                const contentType = outputContentTypes[unsupportedContentTypeIndex];
+                logger(`Unsupported content type ${contentType} for output #${unsupportedContentTypeIndex}`);
+                callback(new RiffError(
+                    errors.types.UNSUPPORTED_OUTPUT_CONTENT_TYPE,
+                    `Unsupported content-type '${contentType}' for output #${unsupportedContentTypeIndex}`));
+                return;
             }
 
             this._wireInputs(transformers);
-            this._wireOutputs(negotiatedOutputContentTypes);
+            this._wireOutputs(normalizedOutputContentTypes);
             this._invoke(callback);
             this._startReceived = true;
             logger('Ready to process data');

--- a/spec/input-unmarshaller.errors.spec.js
+++ b/spec/input-unmarshaller.errors.spec.js
@@ -36,7 +36,7 @@ describe('input unmarshaller =>', () => {
                 });
                 unmarshaller.on('error', (err) => {
                     expect(err.type).toEqual('error-input-content-type-unsupported');
-                    expect(err.cause).toEqual('unsupported input #0\'s content-type application/x-doom');
+                    expect(err.cause).toEqual(`Unsupported content-type 'application/x-doom' for input #0`);
                     done();
                 });
 

--- a/spec/lifecycle.errors.spec.js
+++ b/spec/lifecycle.errors.spec.js
@@ -1,5 +1,6 @@
 const StreamingPipeline = require('../lib/streaming-pipeline');
 const {PassThrough} = require('stream');
+const grpc = require('grpc');
 
 describe('streaming pipeline =>', () => {
 
@@ -8,6 +9,8 @@ describe('streaming pipeline =>', () => {
 
     beforeEach(() => {
         destinationStream = new PassThrough({objectMode: true});
+        destinationStream.call = {};
+        destinationStream.call.cancelWithStatus = jasmine.createSpy('cancelWithStatus');
     });
 
     afterEach(() => {
@@ -26,6 +29,10 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-hook-timeout');
                 expect(err.cause).toEqual('The hook took too long to run. Aborting now');
+                expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                    grpc.status.UNKNOWN,
+                    'Invoker: Unexpected Error: The hook took too long to run. Aborting now'
+                );
                 done();
             });
         });
@@ -42,6 +49,10 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-hook-timeout');
                 expect(err.cause).toEqual('The hook took too long to run. Aborting now');
+                expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                    grpc.status.UNKNOWN,
+                    'Invoker: Unexpected Error: The hook took too long to run. Aborting now'
+                );
                 done();
             });
             destinationStream.end();
@@ -59,6 +70,10 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-hook-runtime-error');
                 expect(err.cause.message).toEqual('oopsie');
+                expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                    grpc.status.UNKNOWN,
+                    'Invoker: Unexpected Error: Error: oopsie'
+                );
                 done();
             });
         });
@@ -75,6 +90,10 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-hook-runtime-error');
                 expect(err.cause.message).toEqual('oopsie');
+                expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                    grpc.status.UNKNOWN,
+                    'Invoker: Unexpected Error: Error: oopsie'
+                );
                 done();
             });
             destinationStream.end();

--- a/spec/output-marshaller.errors.spec.js
+++ b/spec/output-marshaller.errors.spec.js
@@ -3,26 +3,6 @@ const OutputMarshaller = require('../lib/output-marshaller');
 
 describe('output marshaller =>', () => {
 
-    it('fails to instantiate if the output index is invalid', () => {
-        try {
-            new OutputMarshaller(-1, 'text/plain', {});
-            fail('instantiation should fail');
-        } catch (err) {
-            expect(err.type).toEqual('error-output-index-invalid');
-            expect(err.cause).toEqual('invalid output index: -1');
-        }
-    });
-
-    it('fails to instantiate if the content type is not supported', () => {
-        try {
-            new OutputMarshaller(0, 'text/nope', {});
-            fail('instantiation should fail');
-        } catch (err) {
-            expect(err.type).toEqual('error-output-content-type-unsupported');
-            expect(err.cause).toEqual('unrecognized output #0\'s content-type text/nope');
-        }
-    });
-
     ['application/json', 'application/cloudevents+json'].forEach((mediaType) => {
         describe(`with invalid payloads for ${mediaType} =>`, () => {
 

--- a/spec/streaming-pipeline.errors.spec.js
+++ b/spec/streaming-pipeline.errors.spec.js
@@ -262,7 +262,7 @@ describe('streaming pipeline =>', () => {
         })
     });
 
-    describe('with an input that cannot be unmarshalled =>', () => {
+    describe('with an unmarshallable input =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
             inputStreams.$order[0].pipe(outputStreams.$order[0]);
         };
@@ -283,7 +283,10 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-input-invalid');
                 expect(err.cause.message).toEqual('Unexpected token i in JSON at position 0');
-                expect(destinationStream.call.cancelWithStatus).not.toHaveBeenCalled();
+                expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                    grpc.status.UNKNOWN,
+                    'Invoker: Unexpected Error: SyntaxError: Unexpected token i in JSON at position 0'
+                );
                 done();
             });
             fixedSource.pipe(streamingPipeline);
@@ -317,7 +320,10 @@ describe('streaming pipeline =>', () => {
             });
             streamingPipeline.on('error', (err) => {
                 expect(err.message).toEqual('Function failed');
-                expect(destinationStream.call.cancelWithStatus).not.toHaveBeenCalled();
+                expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                    grpc.status.UNKNOWN,
+                    'Invoker: Unexpected Error: Function failed'
+                );
                 done();
             });
             fixedSource.pipe(streamingPipeline);
@@ -351,7 +357,10 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-output-invalid');
                 expect(err.cause.message).toEqual('Cannot convert a Symbol value to a string');
-                expect(destinationStream.call.cancelWithStatus).not.toHaveBeenCalled();
+                expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                    grpc.status.UNKNOWN,
+                    'Invoker: Unexpected Error: TypeError: Cannot convert a Symbol value to a string'
+                );
                 done();
             });
             fixedSource.pipe(streamingPipeline);

--- a/spec/streaming-pipeline.errors.spec.js
+++ b/spec/streaming-pipeline.errors.spec.js
@@ -9,6 +9,7 @@ const {
     newStartFrame,
     newStartSignal
 } = require('./helpers/factories');
+const grpc = require('grpc');
 
 describe('streaming pipeline =>', () => {
     const textEncoder = new TextEncoder();
@@ -18,10 +19,13 @@ describe('streaming pipeline =>', () => {
 
     beforeEach(() => {
         destinationStream = new PassThrough({objectMode: true});
+        destinationStream.call = {};
+        destinationStream.call.cancelWithStatus = jasmine.createSpy('cancelWithStatus');
     });
 
     afterEach(() => {
         destinationStream.destroy();
+        destinationStream.call.cancelWithStatus.calls.reset();
     });
 
     describe('with a reliable function =>', () => {
@@ -41,34 +45,38 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.destroy();
         });
 
-        describe('with badly-typed inputs =>', () => {
+        describe('with malformed input signals =>', () => {
             beforeEach(() => {
                 fixedSource = newFixedSource(["not a signal"]);
             });
 
-            it('emits an error', (done) => {
+            it('cancels the invocation', (done) => {
                 streamingPipeline.on('error', (err) => {
-                    expect(err.type).toEqual('error-streaming-input-invalid');
-                    expect(err.cause).toEqual('invalid input type [object String]');
-                });
-                streamingPipeline.on('finish', () => {
+                    expect(err.type).toEqual('error-streaming-invalid-input-signal');
+                    expect(err.cause).toEqual('Invalid input signal type [object String]');
+                    expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                        grpc.status.UNKNOWN,
+                        'Invoker: Protocol Violation: Invalid input signal type [object String]'
+                    );
                     done();
                 });
                 fixedSource.pipe(streamingPipeline);
             });
         });
 
-        describe('with a buggy input signal =>', () => {
+        describe('with an incomplete input signal =>', () => {
             beforeEach(() => {
                 fixedSource = newFixedSource([newInputSignal(null)]);
             });
 
-            it('emits an error', (done) => {
+            it('cancels the invocation', (done) => {
                 streamingPipeline.on('error', (err) => {
-                    expect(err.type).toEqual('error-streaming-input-invalid');
-                    expect(err.cause).toEqual('input is neither a start nor a data signal');
-                });
-                streamingPipeline.on('finish', () => {
+                    expect(err.type).toEqual('error-streaming-invalid-input-signal');
+                    expect(err.cause).toEqual('Input is neither a start nor a data signal');
+                    expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                        grpc.status.UNKNOWN,
+                        'Invoker: Protocol Violation: Input is neither a start nor a data signal'
+                    );
                     done();
                 });
                 fixedSource.pipe(streamingPipeline);
@@ -83,21 +91,21 @@ describe('streaming pipeline =>', () => {
                 ]);
             });
 
-            it('emits an error', (done) => {
+            it('cancels the invocation', (done) => {
                 destinationStream.on('data', () => {
                     done(new Error('should not receive any data'));
                 });
                 streamingPipeline.on('error', (err) => {
-                    expect(err.type).toEqual('error-streaming-too-many-starts');
+                    expect(err.type).toEqual('error-streaming-too-many-start-signals');
                     expect(err.cause).toEqual(
-                        'start signal has already been received. ' +
-                        'Rejecting start signal with: ' +
-                        'output content types: [application/x-doom], ' +
-                        'input names: [input], ' +
-                        'output names: [output]'
+                        'Start signal has already been received. Rejecting start signal with: ' +
+                        'output content types: [application/x-doom], input names: [input], output names: [output]'
                     );
-                });
-                streamingPipeline.on('finish', () => {
+                    expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                        grpc.status.UNKNOWN,
+                        'Invoker: Protocol Violation: Start signal has already been received. Rejecting start signal ' +
+                        'with: output content types: [application/x-doom], input names: [input], output names: [output]'
+                    );
                     done();
                 });
                 fixedSource.pipe(streamingPipeline);
@@ -112,17 +120,17 @@ describe('streaming pipeline =>', () => {
                 ]);
             });
 
-            it('emits an error', (done) => {
+            it('cancels the invocation', (done) => {
                 destinationStream.on('data', () => {
                     done(new Error('should not receive any data'));
                 });
                 streamingPipeline.on('error', (err) => {
                     expect(err.type).toEqual('error-streaming-invalid-output-count');
-                    expect(err.cause).toEqual(
-                        'invalid output count 3: function has only 1 output(s)'
+                    expect(err.cause).toEqual('Invalid output count 3: function has only 1 output(s)');
+                    expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                        grpc.status.UNKNOWN,
+                        "Invoker: Protocol Violation: Invalid output count 3: function has only 1 output(s)"
                     );
-                });
-                streamingPipeline.on('finish', () => {
                     done();
                 });
                 fixedSource.pipe(streamingPipeline);
@@ -136,18 +144,19 @@ describe('streaming pipeline =>', () => {
                 ]);
             });
 
-            it('emits an error', (done) => {
+            it('cancels the invocation', (done) => {
                 destinationStream.on('data', () => {
                     done(new Error('should not receive any data'));
                 });
                 streamingPipeline.on('error', (err) => {
-                    expect(err.type).toEqual('error-streaming-missing-start');
+                    expect(err.type).toEqual('error-streaming-missing-start-signal');
                     expect(err.cause).toEqual(
-                        'start signal has not been received or processed yet. ' +
-                        'Rejecting data signal'
+                        'Start signal has not been received or processed yet. Rejecting data signal'
                     );
-                });
-                streamingPipeline.on('finish', () => {
+                    expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                        grpc.status.UNKNOWN,
+                        'Invoker: Protocol Violation: Start signal has not been received or processed yet. Rejecting data signal'
+                    );
                     done();
                 });
                 fixedSource.pipe(streamingPipeline);
@@ -155,7 +164,69 @@ describe('streaming pipeline =>', () => {
         });
     });
 
-    describe('with a failing-at-invocation-time function =>', () => {
+    describe('with an unsupported output MIME type =>', () => {
+        const userFunction = (inputStreams, outputStreams) => {
+            inputStreams.$order[0].pipe(outputStreams.$order[0]);
+        };
+        userFunction.$interactionModel = 'node-streams';
+
+        beforeEach(() => {
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            fixedSource = newFixedSource([
+                newStartSignal(newStartFrame(['text/zglorbf'], ['in'], ['out'])),
+                newInputSignal(newInputFrame(0, 'application/json', textEncoder.encode('42')))
+            ]);
+        });
+
+        it('cancels the invocation', (done) => {
+            destinationStream.on('data', () => {
+                done(new Error('should not receive any data'));
+            });
+            streamingPipeline.on('error', (err) => {
+                expect(err.type).toEqual('error-output-content-type-unsupported');
+                expect(err.cause).toEqual(`Unsupported content-type 'text/zglorbf' for output #0`);
+                expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                    grpc.status.INVALID_ARGUMENT,
+                    `Invoker: Not Acceptable: Unsupported content-type 'text/zglorbf' for output #0`
+                );
+                done();
+            });
+            fixedSource.pipe(streamingPipeline);
+        })
+    });
+
+    describe('with an unsupported input MIME type =>', () => {
+        const userFunction = (inputStreams, outputStreams) => {
+            inputStreams.$order[0].pipe(outputStreams.$order[0]);
+        };
+        userFunction.$interactionModel = 'node-streams';
+
+        beforeEach(() => {
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            fixedSource = newFixedSource([
+                newStartSignal(newStartFrame(['text/plain'], ['in'], ['out'])),
+                newInputSignal(newInputFrame(0, 'application/jackson-five', textEncoder.encode('1234')))
+            ]);
+        });
+
+        it('cancels the invocation', (done) => {
+            destinationStream.on('data', () => {
+                done(new Error('should not receive any data'));
+            });
+            streamingPipeline.on('error', (err) => {
+                expect(err.type).toEqual('error-input-content-type-unsupported');
+                expect(err.cause).toEqual(`Unsupported content-type 'application/jackson-five' for input #0`);
+                expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                    grpc.status.INVALID_ARGUMENT,
+                    `Invoker: Unsupported Media Type: Unsupported content-type 'application/jackson-five' for input #0`
+                );
+                done();
+            });
+            fixedSource.pipe(streamingPipeline);
+        })
+    });
+
+    describe('with a function throwing at invocation time =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
             inputStreams["in"].pipe(outputStreams["out"]);
             null.nope();
@@ -174,15 +245,17 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.destroy();
         });
 
-        it('ends the pipeline', (done) => {
+        it('cancels the invocation', (done) => {
             destinationStream.on('data', () => {
                 done(new Error('should not receive any data'));
             });
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('streaming-function-runtime-error');
                 expect(err.cause.message).toEqual(`Cannot read property 'nope' of null`);
-            });
-            streamingPipeline.on('finish', () => {
+                expect(destinationStream.call.cancelWithStatus).toHaveBeenCalledWith(
+                    grpc.status.UNKNOWN,
+                    "Invoker: Unexpected Invocation Error: Cannot read property 'nope' of null"
+                );
                 done();
             });
             fixedSource.pipe(streamingPipeline);
@@ -203,25 +276,21 @@ describe('streaming pipeline =>', () => {
             ]);
         });
 
-        it('ends the pipeline', (done) => {
+        it('emits the error', (done) => {
             destinationStream.on('data', () => {
                 done(new Error('should not receive any data'));
             });
-            let errored = false;
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-input-invalid');
                 expect(err.cause.message).toEqual('Unexpected token i in JSON at position 0');
-                errored = true;
-            });
-            streamingPipeline.on('finish', () => {
-                expect(errored).toBeTruthy('pipeline should have errored');
+                expect(destinationStream.call.cancelWithStatus).not.toHaveBeenCalled();
                 done();
             });
             fixedSource.pipe(streamingPipeline);
         })
     });
 
-    describe('with a function that fails when receiving data =>', () => {
+    describe('with a function throwing when receiving data =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
             inputStreams.$order[0].pipe(new SimpleTransform({objectMode: true}, () => {
                 throw new Error('Function failed')
@@ -242,24 +311,20 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.destroy();
         });
 
-        it('ends the pipeline', (done) => {
+        it('emits the error', (done) => {
             destinationStream.on('data', () => {
                 done(new Error('should not receive any data'));
             });
-            let errored = false;
             streamingPipeline.on('error', (err) => {
                 expect(err.message).toEqual('Function failed');
-                errored = true;
-            });
-            streamingPipeline.on('finish', () => {
-                expect(errored).toBeTruthy('pipeline should have errored');
+                expect(destinationStream.call.cancelWithStatus).not.toHaveBeenCalled();
                 done();
             });
             fixedSource.pipe(streamingPipeline);
         })
     });
 
-    describe('with a function producing outputs that cannot be marshalled =>', () => {
+    describe('with a function producing unmarshallable outputs =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
             inputStreams.$order[0].pipe(new SimpleTransform({objectMode: true}, (x) => Symbol(x)))
                 .pipe(outputStreams.$order[0]);
@@ -279,18 +344,14 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.destroy();
         });
 
-        it('ends the pipeline', (done) => {
+        it('emits the error', (done) => {
             destinationStream.on('data', () => {
                 done(new Error('should not receive any data'));
             });
-            let errored = false;
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-output-invalid');
                 expect(err.cause.message).toEqual('Cannot convert a Symbol value to a string');
-                errored = true;
-            });
-            streamingPipeline.on('finish', () => {
-                expect(errored).toBeTruthy('pipeline should have errored');
+                expect(destinationStream.call.cancelWithStatus).not.toHaveBeenCalled();
                 done();
             });
             fixedSource.pipe(streamingPipeline);
@@ -347,7 +408,7 @@ describe('streaming pipeline =>', () => {
             streamingPipeline.destroy();
         });
 
-        it('ends the pipeline', (done) => {
+        it('emits an error', (done) => {
             destinationStream.on('data', () => {
                 done(new Error('should not receive any data'));
             });
@@ -360,12 +421,13 @@ describe('streaming pipeline =>', () => {
         })
     });
 
-    describe('with a request-reply function', () => {
+    describe('with a request-reply function =>', () => {
+
         it('throws an error when constructing', () => {
             const userFunction = () => 42;
             userFunction.$interactionModel = "request-reply";
-            const construct = () => new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
-            expect(construct).toThrow(new Error(`SteamingPipeline expects a function with "node-streams" interaction model, but was "request-reply" instead`));
+            expect(() => new StreamingPipeline(userFunction, destinationStream, {objectMode: true}))
+                .toThrow(new Error(`SteamingPipeline expects a function with "node-streams" interaction model, but was "request-reply" instead`));
         })
     });
 });


### PR DESCRIPTION
Includes specific gRPC status errors for unsupported input/output
MIME types (see https://github.com/projectriff/invoker-specification/issues/12
and https://github.com/projectriff/invoker-specification/issues/13).

The invocation is also canceled when an invalid signal sequence
occurs or when the function throws at invocation time.

---
# How to validate

## Start the adapter
Make sure it includes https://github.com/projectriff/streaming-http-adapter/commit/b1bbbaf30f2e84a0e102fc144b251da108a0d656
```shell
 $ FUNCTION_URI=~/node-square/square.js NODE_DEBUG='riff' ./streaming-http-adapter npm --prefix ~/workspace/node-function-invoker start
```

## Scenario 1: unsupported output content type
```shell
 $ curl http://localhost:8080 -d'4' -H'Content-Type: application/json' -H'Accept:text/zglorbf' -v
[...]
< HTTP/1.1 406 Not Acceptable
< Date: Wed, 05 Feb 2020 14:39:49 GMT
< Content-Length: 79
< Content-Type: text/plain; charset=utf-8
<
Invoker: Not Acceptable: Unsupported content-type 'text/zglorbf' for output #0
```

## Scenario 2: unsupported output content type
```shell
 $ curl http://localhost:8080 -d'4' -H'Content-Type: application/jackson-five' -H'Accept:text/plain' -v
[...]
< HTTP/1.1 415 Unsupported Media Type
< Date: Wed, 05 Feb 2020 14:42:00 GMT
< Content-Length: 98
< Content-Type: text/plain; charset=utf-8
<
Invoker: Unsupported Media Type: Unsupported content-type 'application/jackson-five' for input #0
```
## Scenario 3: another error
```shell
 $ curl http://localhost:8080 -d'invalid JSON' -H'Content-Type: application/json' -H'Accept:text/plain' -v
[...]
< HTTP/1.1 500 Internal Server Error
< Date: Wed, 05 Feb 2020 14:43:55 GMT
< Content-Length: 81
< Content-Type: text/plain; charset=utf-8
<
Invoker: Unexpected Error: SyntaxError: Unexpected token i in JSON at position 0
```

