### PR TITLE
Fix unhandled promise rejection

### DIFF
--- a/lib/mapping-transform.js
+++ b/lib/mapping-transform.js
@@ -9,26 +9,22 @@ module.exports = class MappingTransform extends Transform {
     }
 
     _transform(chunk, _, callback) {
-        try {
-            Promise.resolve(this._function(chunk)).then(
-                this._handleResult(callback),
-                this._handleError.bind(this)
-            );
-        } catch (err) {
-            Promise.resolve(err).then(this._handleError.bind(this));
-        }
-    }
-
-    _handleResult(callback) {
-        return (result) => {
-            callback(null, result);
-        };
-    }
-
-    _handleError(err) {
-        this.emit(
-            "error",
-            new RiffError(errorTypes.REQUEST_REPLY_FUNCTION_RUNTIME, err)
-        );
+        Promise.resolve(chunk)
+            .then(this._function)
+            .then(
+                (result) => callback(null, result),
+                (err) =>
+                    callback(
+                        new RiffError(
+                            errorTypes.REQUEST_REPLY_FUNCTION_RUNTIME,
+                            err
+                        )
+                    )
+            )
+            .catch((err) => {
+                console.error(
+                    `Unexpected error happened when mapping request-reply function: ${err}`
+                );
+            });
     }
 };

--- a/lib/request-reply-promoter.js
+++ b/lib/request-reply-promoter.js
@@ -31,6 +31,9 @@ module.exports = (userFunction) => {
     console.debug("Promoting request-reply function to streaming function");
     const mapper = new MappingTransform(userFunction);
     const promotedFunction = (inputs, outputs) => {
+        mapper.on("error", (err) => {
+            inputs.$order[0].emit("error", err);
+        });
         inputs.$order[0].pipe(mapper).pipe(outputs.$order[0]);
     };
     promotedFunction.$interactionModel = "node-streams";

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -226,11 +226,23 @@ module.exports = class StreamingPipeline extends Writable {
         for (let i = 0; i < inputCount; i++) {
             const unmarshaller = new InputUnmarshaller(transformers[i]);
             unmarshaller.on("error", (err) => {
-                console.error(`error from unmarshaller: ${err.toString()}`);
+                console.error(
+                    `error from ${this._errorOrigin(err)}: ${err.toString()}`
+                );
                 this.emit("error", err);
             });
             this._functionInputs[i] = unmarshaller;
         }
+    }
+
+    _errorOrigin(err) {
+        if (
+            err.type &&
+            err.type === errors.types.REQUEST_REPLY_FUNCTION_RUNTIME
+        ) {
+            return "request-reply function";
+        }
+        return "unmarshaller";
     }
 
     _wireOutputs(outputContentTypes) {

--- a/spec/request-reply-promoter.errors.spec.js
+++ b/spec/request-reply-promoter.errors.spec.js
@@ -1,4 +1,5 @@
 const promoteFunction = require("../lib/request-reply-promoter");
+const { PassThrough } = require("stream");
 
 describe("function promoter =>", () => {
     describe("when called with functions with an argument transformer => ", () => {
@@ -26,6 +27,36 @@ describe("function promoter =>", () => {
                     "Request-reply function must declare exactly 1 argument transformer. Found 2"
                 );
             }
+        });
+    });
+
+    describe("when the called function throws => ", () => {
+        const userFunction = (x) => {
+            throw new Error("nope");
+        };
+
+        it("propagates the error back to the input stream", (done) => {
+            const streamingUserFunction = promoteFunction(userFunction);
+            const input = new PassThrough({ objectMode: true });
+            const output = new PassThrough({ objectMode: true });
+
+            input.on("error", (err) => {
+                expect(err.type).toEqual(
+                    "request-reply-function-runtime-error"
+                );
+                expect(err.cause).toEqual(new Error("nope"));
+                done();
+            });
+            output.on("error", (err) => {
+                done(
+                    new Error(
+                        `Expected output to not receive any error, got: ${err}`
+                    )
+                );
+            });
+
+            streamingUserFunction({ $order: [input] }, { $order: [output] });
+            input.write("irrelevant value");
         });
     });
 });


### PR DESCRIPTION
Fixes #133.

## How to validate

1. create the following function, e.g. `/tmp/joy_division.js`:
```js
module.exports = (x) => {
        if (x === 0) {
                throw new Error('Division by zero');
        }
        return 100 / x;
}
```
or even `/tmp/async_joy_division.js`:
```js
module.exports = async (x) => {
        if (x === 0) {
                throw new Error('Division by zero');
        }
        return 100 / x;
}
```
2. point the node invoker to the PR branch
3. build (`make`) and run the [adapter](https://github.com/projectriff/streaming-http-adapter)
```shell
FUNCTION_URI=/tmp/joy_division.js NODE_DEBUG='riff' ./streaming-http-adapter npm --prefix ~/workspace/node-function-invoker start
```
4. send a failing request
```shell
curl http://localhost:8080 -H'Content-Type:application/json' -d'0' -H'Accept:text/plain' -v
```

The request should not hang and a 500 response should be received.