### PR TITLE
Exclude Node 13.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "lib/**/*.js",
     "proto/**/*.js",
     "server.js"
-  ]
+  ],
+  "engines": {
+    "node": ">=0.10 <0.13"
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/projectriff/node-function-buildpack/issues/127.

Note that this potentially includes Node 11, but it is not a
problem, for several reasons:

 - the invoker test suite has no issue with Node 11
 - the Node buildpack only offers Node 10 (LTS), 12 (LTS) and 13
(latest) at the time of writing