### PR TITLE
Drop stream options

### DIFF
--- a/lib/input-unmarshaller.js
+++ b/lib/input-unmarshaller.js
@@ -20,8 +20,8 @@ const convertToRiffMessage = (payload, headers) => {
 
 module.exports = class InputUnmarshaller extends Transform {
 
-    constructor(options, argumentTransformer) {
-        super(options);
+    constructor(argumentTransformer) {
+        super({ objectMode: true });
         this.argumentTransformer = argumentTransformer || DEFAULT_ARGUMENT_TRANSFORMER;
     }
 

--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -19,7 +19,7 @@ const invoke = (userFunction) => {
     return (call) => {
         logger('New invocation started');
         const normalizedUserFunction = promoteRequestReplyFunction(userFunction);
-        const pipeline = new StreamingPipeline(normalizedUserFunction, call, { objectMode: true });
+        const pipeline = new StreamingPipeline(normalizedUserFunction, call);
         call.pipe(pipeline);
     };
 };

--- a/lib/mapping-transform.js
+++ b/lib/mapping-transform.js
@@ -4,8 +4,8 @@ const {types: errorTypes} = require('./errors');
 
 module.exports = class MappingTransform extends Transform {
 
-    constructor(fn, options) {
-        super(options);
+    constructor(fn) {
+        super({ objectMode: true });
         this._function = fn;
 
     }

--- a/lib/output-marshaller.js
+++ b/lib/output-marshaller.js
@@ -7,8 +7,8 @@ const {AbstractMessage, Message} = require('@projectriff/message');
 
 module.exports = class OutputMarshaller extends Transform {
 
-    constructor(index, contentType, options) {
-        super(options);
+    constructor(index, contentType) {
+        super({ objectMode: true });
         this._index = index;
         this._acceptedContentType = contentType;
         this._marshallerFunction = marshaller(this._acceptedContentType);

--- a/lib/request-reply-promoter.js
+++ b/lib/request-reply-promoter.js
@@ -50,7 +50,7 @@ module.exports = (userFunction) => {
     }
 
     logger('Promoting request-reply function to streaming function');
-    const mapper = new MappingTransform(userFunction, {objectMode: true});
+    const mapper = new MappingTransform(userFunction);
     const promotedFunction = (inputs, outputs) => {
         inputs.$order[0]
             .pipe(mapper)

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -25,14 +25,13 @@ const validateTransformers = (transformers) => {
 
 module.exports = class StreamingPipeline extends Writable {
 
-    constructor(userFunction, grpcStream, options) {
-        super(options);
+    constructor(userFunction, grpcStream, options={}) {
+        super({ objectMode: true });
         if (userFunction.$interactionModel !== 'node-streams') {
             throw new Error(`SteamingPipeline expects a function with "node-streams" interaction model, but was "${userFunction.$interactionModel}" instead`);
         }
 
         validateTransformers(userFunction['$argumentTransformers']);
-        this._options = options;
         this._hookTimeoutInMs = options['hookTimeoutInMs'] || 10000;
         this._userFunction = userFunction;
         this._destinationStream = grpcStream;
@@ -211,7 +210,7 @@ module.exports = class StreamingPipeline extends Writable {
         const inputCount = transformers.length;
         logger(`Wiring ${inputCount} input stream(s)`);
         for (let i = 0; i < inputCount; i++) {
-            const inputUnmarshaller = new InputUnmarshaller(this._options, transformers[i]);
+            const inputUnmarshaller = new InputUnmarshaller(transformers[i]);
             inputUnmarshaller.on('error', (err) => {
                 logger(`error from unmarshaller: ${err.toString()}`);
                 this.emit('error', err);
@@ -224,7 +223,7 @@ module.exports = class StreamingPipeline extends Writable {
         const outputCount = outputContentTypes.length;
         logger(`Wiring ${outputCount} output stream(s)`);
         for (let i = 0; i < outputCount; i++) {
-            const marshaller = new OutputMarshaller(i, outputContentTypes[i], this._options);
+            const marshaller = new OutputMarshaller(i, outputContentTypes[i]);
             marshaller.pipe(this._destinationStream, {end: false});
             marshaller.on('finish', () => {
                 this._finishedOutputs++;

--- a/spec/helpers/factories.js
+++ b/spec/helpers/factories.js
@@ -49,10 +49,10 @@ module.exports = {
         return outputSignal;
     },
     'newFixedSource': (data) => {
-        return new FixedSource(data, {objectMode: true})
+        return new FixedSource(data)
     },
     'newMappingTransform': (fn) => {
-        return new MappingTransform(fn, {objectMode: true})
+        return new MappingTransform(fn)
     },
     'newRiffMessage': (headers, payload) => {
         return Message.builder().headers(headers).payload(payload).build();

--- a/spec/helpers/fixed-source.js
+++ b/spec/helpers/fixed-source.js
@@ -3,8 +3,8 @@ const {min} = Math;
 
 module.exports = class FixedSource extends Readable {
 
-    constructor(values, options) {
-        super(options);
+    constructor(values) {
+        super({objectMode: true});
         this.values = values;
         this.length = this.values.length;
         this._index = 0;

--- a/spec/helpers/hooks/simple-lifecycle-streaming-function.js
+++ b/spec/helpers/hooks/simple-lifecycle-streaming-function.js
@@ -5,7 +5,7 @@ let counter = Number.MIN_SAFE_INTEGER;
 module.exports = (inputStreams, outputStreams) => {
     inputStreams.$order[0].pipe(new MappingTransform((x) => {
         return x ** 2;
-    }, {objectMode: true})).pipe(outputStreams.$order[0]);
+    })).pipe(outputStreams.$order[0]);
 };
 module.exports.$interactionModel = 'node-streams';
 

--- a/spec/input-unmarshaller.errors.spec.js
+++ b/spec/input-unmarshaller.errors.spec.js
@@ -9,7 +9,7 @@ describe('input unmarshaller =>', () => {
         let unmarshaller;
 
         beforeEach(() => {
-            unmarshaller = new InputUnmarshaller({objectMode: true});
+            unmarshaller = new InputUnmarshaller();
         });
 
         afterEach(() => {
@@ -82,7 +82,7 @@ describe('input unmarshaller =>', () => {
         let inputs;
 
         beforeEach(() => {
-            unmarshaller = new InputUnmarshaller({objectMode: true}, (message) => {
+            unmarshaller = new InputUnmarshaller((message) => {
                 throw new Error(message.payload + ' ko');
             });
             inputs = newFixedSource([

--- a/spec/input-unmarshaller.spec.js
+++ b/spec/input-unmarshaller.spec.js
@@ -9,7 +9,7 @@ describe('input unmarshaller =>', () => {
         let unmarshaller;
 
         beforeEach(() => {
-            unmarshaller = new InputUnmarshaller({objectMode: true});
+            unmarshaller = new InputUnmarshaller();
         });
 
         afterEach(() => {
@@ -91,7 +91,7 @@ describe('input unmarshaller =>', () => {
         const outputData = [42, 2];
 
         beforeEach(() => {
-            unmarshaller = new InputUnmarshaller({objectMode: true}, (msg) => msg.payload.age);
+            unmarshaller = new InputUnmarshaller((msg) => msg.payload.age);
             inputs = newFixedSource([
                 newInputSignal(newInputFrame(0, 'application/json', textEncoder.encode(inputData[0]))),
                 newInputSignal(newInputFrame(0, 'application/json', textEncoder.encode(inputData[1]))),
@@ -126,7 +126,7 @@ describe('input unmarshaller =>', () => {
         const headers = ["the truth is...", "... still out there"];
 
         beforeEach(() => {
-            unmarshaller = new InputUnmarshaller({objectMode: true}, (msg) => msg.headers.getValue('X-Files'));
+            unmarshaller = new InputUnmarshaller((msg) => msg.headers.getValue('X-Files'));
             inputs = newFixedSource([
                 newInputSignal(newInputFrame(0, 'application/json', textEncoder.encode('"ignored"'), [["X-Files", headers[0]]])),
                 newInputSignal(newInputFrame(0, 'application/json', textEncoder.encode('"ignored"'), [["X-Files", headers[1]]])),

--- a/spec/lifecycle.errors.spec.js
+++ b/spec/lifecycle.errors.spec.js
@@ -23,8 +23,7 @@ describe('streaming pipeline =>', () => {
 
         it('emits an error', (done) => {
             streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {
-                objectMode: true,
-                hookTimeoutInMs: 100
+                hookTimeoutInMs: 10
             });
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-hook-timeout');
@@ -43,8 +42,7 @@ describe('streaming pipeline =>', () => {
 
         it('emits an error', (done) => {
             streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {
-                objectMode: true,
-                hookTimeoutInMs: 100
+                hookTimeoutInMs: 10
             });
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-hook-timeout');
@@ -63,10 +61,7 @@ describe('streaming pipeline =>', () => {
         const userFunction = require('./helpers/hooks/failing-init-hook-streaming-function');
 
         it('emits an error', (done) => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {
-                objectMode: true,
-                hookTimeoutInMs: 100
-            });
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-hook-runtime-error');
                 expect(err.cause.message).toEqual('oopsie');
@@ -83,10 +78,7 @@ describe('streaming pipeline =>', () => {
         const userFunction = require('./helpers/hooks/failing-destroy-hook-streaming-function');
 
         it('emits an error', (done) => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {
-                objectMode: true,
-                hookTimeoutInMs: 100
-            });
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
             streamingPipeline.on('error', (err) => {
                 expect(err.type).toEqual('error-hook-runtime-error');
                 expect(err.cause.message).toEqual('oopsie');

--- a/spec/lifecycle.spec.js
+++ b/spec/lifecycle.spec.js
@@ -19,7 +19,7 @@ describe('streaming pipeline =>', () => {
         const userFunction = require('./helpers/hooks/simple-lifecycle-streaming-function');
 
         beforeEach(() => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
         });
 
         it('invokes the $init hook when the pipeline is instantiated', () => {

--- a/spec/mapping-transform.errors.spec.js
+++ b/spec/mapping-transform.errors.spec.js
@@ -10,7 +10,7 @@ describe('MappingTransform =>', () => {
 
     describe('when dealing with synchronous functions =>', () => {
         beforeEach(() => {
-            mappingTransform = new MappingTransform((x) => x.foo(), {objectMode: true});
+            mappingTransform = new MappingTransform((x) => x.foo());
         });
 
         it('intercepts runtime errors and sends error events', (done) => {
@@ -29,7 +29,7 @@ describe('MappingTransform =>', () => {
 
     describe('when dealing with asynchronous functions =>', () => {
         beforeEach(() => {
-            mappingTransform = new MappingTransform(async (x) => x.foo(), {objectMode: true});
+            mappingTransform = new MappingTransform(async (x) => x.foo());
         });
 
         it('intercepts async runtime errors and sends error events', (done) => {
@@ -48,7 +48,7 @@ describe('MappingTransform =>', () => {
 
     describe('when dealing with promise-based functions =>', () => {
         beforeEach(() => {
-            mappingTransform = new MappingTransform((x) => Promise.resolve(x.foo()), {objectMode: true});
+            mappingTransform = new MappingTransform((x) => Promise.resolve(x.foo()));
         });
 
         it('intercepts async runtime errors and sends error events', (done) => {

--- a/spec/mapping-transform.spec.js
+++ b/spec/mapping-transform.spec.js
@@ -11,7 +11,7 @@ describe('MappingTransform =>', () => {
     describe('when dealing with non-streaming synchronous functions =>', () => {
         beforeEach(() => {
             const synchronousFunction = (x) => x.foo();
-            mappingTransform = new MappingTransform(synchronousFunction, {objectMode: true});
+            mappingTransform = new MappingTransform(synchronousFunction);
         });
 
         it('maps them to streaming transform', (done) => {
@@ -26,7 +26,7 @@ describe('MappingTransform =>', () => {
     describe('when dealing with non-streaming asynchronous functions =>', () => {
         beforeEach(() => {
             const asynchronousFunction = async (x) => x.foo();
-            mappingTransform = new MappingTransform(asynchronousFunction, {objectMode: true});
+            mappingTransform = new MappingTransform(asynchronousFunction);
         });
 
         it('maps them to streaming transform', (done) => {
@@ -41,7 +41,7 @@ describe('MappingTransform =>', () => {
     describe('when dealing with non-streaming promise-based functions =>', () => {
         beforeEach(() => {
             const asynchronousFunction = (x) => Promise.resolve(x.foo());
-            mappingTransform = new MappingTransform(asynchronousFunction, {objectMode: true});
+            mappingTransform = new MappingTransform(asynchronousFunction);
         });
 
         it('maps them to streaming transform', (done) => {

--- a/spec/output-marshaller.errors.spec.js
+++ b/spec/output-marshaller.errors.spec.js
@@ -10,7 +10,7 @@ describe('output marshaller =>', () => {
             let outputPayloadSource;
 
             beforeEach(() => {
-                marshaller = new OutputMarshaller(0, mediaType, {objectMode: true});
+                marshaller = new OutputMarshaller(0, mediaType);
                 outputPayloadSource = newFixedSource([Symbol(42)]);
             });
 

--- a/spec/output-marshaller.spec.js
+++ b/spec/output-marshaller.spec.js
@@ -16,7 +16,7 @@ describe('output marshaller =>', () => {
         describe(`with ${mediaType} data =>`, () => {
             beforeEach(() => {
                 source = newFixedSource(outputPayloads);
-                marshaller = new OutputMarshaller(expectedIndex, mediaType, {objectMode: true});
+                marshaller = new OutputMarshaller(expectedIndex, mediaType);
             });
 
             afterEach(() => {
@@ -53,7 +53,7 @@ describe('output marshaller =>', () => {
                 .addHeader('Content-Type', 'text/csv', 'ignored')
                 .addHeader('X-Custom-Header', 'custom value');
             source = newFixedSource([newRiffMessage(messageHeaders, payload)]);
-            marshaller = new OutputMarshaller(0, mediaType, {objectMode: true});
+            marshaller = new OutputMarshaller(0, mediaType);
         });
 
         afterEach(() => {

--- a/spec/streaming-pipeline.errors.spec.js
+++ b/spec/streaming-pipeline.errors.spec.js
@@ -37,7 +37,7 @@ describe('streaming pipeline =>', () => {
         userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
         });
 
         afterEach(() => {
@@ -171,7 +171,7 @@ describe('streaming pipeline =>', () => {
         userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
             fixedSource = newFixedSource([
                 newStartSignal(newStartFrame(['text/zglorbf'], ['in'], ['out'])),
                 newInputSignal(newInputFrame(0, 'application/json', textEncoder.encode('42')))
@@ -202,7 +202,7 @@ describe('streaming pipeline =>', () => {
         userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
             fixedSource = newFixedSource([
                 newStartSignal(newStartFrame(['text/plain'], ['in'], ['out'])),
                 newInputSignal(newInputFrame(0, 'application/jackson-five', textEncoder.encode('1234')))
@@ -234,7 +234,7 @@ describe('streaming pipeline =>', () => {
         userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
             fixedSource = newFixedSource([
                 newStartSignal(newStartFrame(['text/plain'], ['in'], ['out']))
             ]);
@@ -269,7 +269,7 @@ describe('streaming pipeline =>', () => {
         userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
             fixedSource = newFixedSource([
                 newStartSignal(newStartFrame(['text/plain'], ['in'], ['out'])),
                 newInputSignal(newInputFrame(0, 'application/json', textEncoder.encode('invalid-json')))
@@ -295,14 +295,14 @@ describe('streaming pipeline =>', () => {
 
     describe('with a function throwing when receiving data =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
-            inputStreams.$order[0].pipe(new SimpleTransform({objectMode: true}, () => {
+            inputStreams.$order[0].pipe(new SimpleTransform(() => {
                 throw new Error('Function failed')
             })).pipe(outputStreams.$order[0]);
         };
         userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
             fixedSource = newFixedSource([
                 newStartSignal(newStartFrame(['text/plain'], ['in'], ['out'])),
                 newInputSignal(newInputFrame(0, 'application/json', textEncoder.encode('42')))
@@ -332,13 +332,13 @@ describe('streaming pipeline =>', () => {
 
     describe('with a function producing unmarshallable outputs =>', () => {
         const userFunction = (inputStreams, outputStreams) => {
-            inputStreams.$order[0].pipe(new SimpleTransform({objectMode: true}, (x) => Symbol(x)))
+            inputStreams.$order[0].pipe(new SimpleTransform((x) => Symbol(x)))
                 .pipe(outputStreams.$order[0]);
         };
         userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
             fixedSource = newFixedSource([
                 newStartSignal(newStartFrame(['text/plain'], ['in'], ['out'])),
                 newInputSignal(newInputFrame(0, 'application/json', textEncoder.encode('42')))
@@ -371,7 +371,7 @@ describe('streaming pipeline =>', () => {
         it('rejects the function with an invalid declaration of transformers ', () => {
             try {
                 const userFunction = require('./helpers/transformers/invalid-argument-transformers-streaming-function');
-                new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+                new StreamingPipeline(userFunction, destinationStream);
                 fail('should fail');
             } catch (err) {
                 expect(err.type).toEqual('error-argument-transformer');
@@ -382,7 +382,7 @@ describe('streaming pipeline =>', () => {
         it('rejects the function with an invalid transformer ', () => {
             try {
                 const userFunction = require('./helpers/transformers/invalid-argument-transformer-streaming-function');
-                new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+                new StreamingPipeline(userFunction, destinationStream);
                 fail('should fail');
             } catch (err) {
                 expect(err.type).toEqual('error-argument-transformer');
@@ -393,7 +393,7 @@ describe('streaming pipeline =>', () => {
         it('rejects the function with a transformer with a wrong arity', () => {
             try {
                 const userFunction = require('./helpers/transformers/wrong-arity-argument-transformers-streaming-function');
-                new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+                new StreamingPipeline(userFunction, destinationStream);
                 fail('should fail');
             } catch (err) {
                 expect(err.type).toEqual('error-argument-transformer');
@@ -406,7 +406,7 @@ describe('streaming pipeline =>', () => {
         const userFunction = require('./helpers/transformers/invalid-argument-transformer-count-streaming-function');
 
         beforeEach(() => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
             fixedSource = newFixedSource([
                 newStartSignal(newStartFrame(['text/plain'], ['in1', 'in2'], ['out']))
             ]);
@@ -435,15 +435,15 @@ describe('streaming pipeline =>', () => {
         it('throws an error when constructing', () => {
             const userFunction = () => 42;
             userFunction.$interactionModel = "request-reply";
-            expect(() => new StreamingPipeline(userFunction, destinationStream, {objectMode: true}))
+            expect(() => new StreamingPipeline(userFunction, destinationStream))
                 .toThrow(new Error(`SteamingPipeline expects a function with "node-streams" interaction model, but was "request-reply" instead`));
         })
     });
 });
 
 class SimpleTransform extends Transform {
-    constructor(options, fn) {
-        super(options);
+    constructor(fn) {
+        super({ objectMode: true });
         this.fn = fn;
     }
 

--- a/spec/streaming-pipeline.spec.js
+++ b/spec/streaming-pipeline.spec.js
@@ -35,7 +35,7 @@ describe('streaming pipeline =>', () => {
         userFunction.$interactionModel = 'node-streams';
 
         beforeEach(() => {
-            streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+            streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
         });
 
         describe('with valid input signals =>', () => {
@@ -91,7 +91,7 @@ describe('streaming pipeline =>', () => {
                 };
                 userFunction.$interactionModel = 'node-streams';
 
-                streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+                streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
                 streamingPipeline.on('finish', () => {
                     expect(inputEnded).toBeTruthy('input stream should have been ended');
                     done();
@@ -126,7 +126,7 @@ describe('streaming pipeline =>', () => {
                     expect(receivedOutputSignalCount).toEqual(data.length, `expected to see only ${data.length}, seen ${receivedOutputSignalCount}`);
                     done();
                 });
-                streamingPipeline = new StreamingPipeline(userFunction, destinationStream, {objectMode: true});
+                streamingPipeline = new StreamingPipeline(userFunction, destinationStream);
                 fixedSource.pipe(streamingPipeline);
             })
         });


### PR DESCRIPTION
riff defined streams are only valid in objectMode. we don't need each
instance to be manually placed into objectMode. Since the stream options
can include unintended behavior, like a transform function, it's safer
to not allow external options to be defined.