### PR TITLE
Run tests with Node 2 last LTS versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,19 @@ on:
 jobs:
 
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version:
+          - 10.x
+          - 12.x
+#          - 13.x # blocked by https://github.com/projectriff/node-function-invoker/issues/130
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: ${{ matrix.node_version }}
     - name: Install
       run: npm install
     - name: Test


### PR DESCRIPTION
Fixes #144

Running against latest Node version is blocked by #130.