### PR TITLE
Change output content type preference to favor json

### DIFF
--- a/lib/content-negotiation.js
+++ b/lib/content-negotiation.js
@@ -20,9 +20,9 @@ const mediaTypeNegotiator = require("negotiator/lib/mediaType");
 const contentTypeParser = require("content-type");
 
 const SUPPORTED_MEDIA_TYPES = [
+    "application/json",
     "text/plain",
     "application/octet-stream",
-    "application/json",
     "application/x-www-form-urlencoded",
     "application/cloudevents+json",
 ]; // In preference order

--- a/spec/content-negotiation.spec.js
+++ b/spec/content-negotiation.spec.js
@@ -1,0 +1,30 @@
+const { determineContentTypes } = require("../lib/content-negotiation");
+
+describe("content negotiation =>", () => {
+    describe("determine content-type =>", () => {
+        it("defaults to plain text", async () => {
+            const detected = determineContentTypes(undefined, undefined);
+
+            expect(detected.contentType).toBe("text/plain");
+            expect(detected.accept).toBe("text/plain");
+        });
+        it("defaults missing accept to content type", async () => {
+            const detected = determineContentTypes(
+                "application/cloudevents+json",
+                undefined
+            );
+
+            expect(detected.contentType).toBe("application/cloudevents+json");
+            expect(detected.accept).toBe("application/cloudevents+json");
+        });
+        it("defaults wildcard accept to json", async () => {
+            const detected = determineContentTypes(
+                "application/cloudevents+json",
+                "*/*"
+            );
+
+            expect(detected.contentType).toBe("application/cloudevents+json");
+            expect(detected.accept).toBe("application/json");
+        });
+    });
+});


### PR DESCRIPTION
Currently, output that uses a wildcard accept header defaults to plain
text. While this is the most compatible for clients, it returns garbage
when the function returns an object, or something with structure.

JSON, while less understood by clients, is able to handle a wider
variety of function outputs. Ultimately, clients should send an Accept
header to pick the type they actually want.

Refs #180