### PR TITLE
add invalid grpc code to invalid content type to support abc in strea…

### DIFF
--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -172,6 +172,7 @@ module.exports = class StreamingPipeline extends Writable {
                     details: `${errors.reserved_prefixes.NOT_ACCEPTABLE}: ${err.cause}`,
                 };
             case errors.types.UNSUPPORTED_INPUT_CONTENT_TYPE:
+            case errors.types.INVALID_INPUT_CONTENT_TYPE:
                 return {
                     code: grpc.status.INVALID_ARGUMENT,
                     details: `${errors.reserved_prefixes.UNSUPPORTED_MEDIA_TYPE}: ${err.cause}`,


### PR DESCRIPTION
INVALID_INPUT_CONTENT_TYPE error such as 'content-type: abc' returns grpc invalid_arg status, so that streaming-http-adapter can handle it as http 415 status.