### PR TITLE
set invalid_input error to grpc status code invalid_arg

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -28,5 +28,6 @@ module.exports = {
     reserved_prefixes: {
         NOT_ACCEPTABLE: "Invoker: Not Acceptable",
         UNSUPPORTED_MEDIA_TYPE: "Invoker: Unsupported Media Type",
+        BAD_REQUEST: "Invoker: Bad Request",
     },
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -28,6 +28,6 @@ module.exports = {
     reserved_prefixes: {
         NOT_ACCEPTABLE: "Invoker: Not Acceptable",
         UNSUPPORTED_MEDIA_TYPE: "Invoker: Unsupported Media Type",
-        BAD_REQUEST: "Invoker: Bad Request",
+        BAD_INPUT_SIGNAL: "Invoker: Bad Input Signal",
     },
 };

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -177,6 +177,11 @@ module.exports = class StreamingPipeline extends Writable {
                     code: grpc.status.INVALID_ARGUMENT,
                     details: `${errors.reserved_prefixes.UNSUPPORTED_MEDIA_TYPE}: ${err.cause}`,
                 };
+            case errors.types.INVALID_INPUT:
+                return {
+                    code: grpc.status.INVALID_ARGUMENT,
+                    details: `${errors.reserved_prefixes.BAD_REQUEST}: ${err.cause}`,
+                };
             case errors.types.STREAMING_FUNCTION_RUNTIME:
                 return {
                     code: grpc.status.UNKNOWN,

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -180,7 +180,7 @@ module.exports = class StreamingPipeline extends Writable {
             case errors.types.INVALID_INPUT:
                 return {
                     code: grpc.status.INVALID_ARGUMENT,
-                    details: `${errors.reserved_prefixes.BAD_REQUEST}: ${err.cause}`,
+                    details: `${errors.reserved_prefixes.BAD_INPUT_SIGNAL}: ${err.cause}`,
                 };
             case errors.types.STREAMING_FUNCTION_RUNTIME:
                 return {

--- a/lib/streaming-pipeline.js
+++ b/lib/streaming-pipeline.js
@@ -172,6 +172,7 @@ module.exports = class StreamingPipeline extends Writable {
                     details: `${errors.reserved_prefixes.NOT_ACCEPTABLE}: ${err.cause}`,
                 };
             case errors.types.UNSUPPORTED_INPUT_CONTENT_TYPE:
+            case errors.types.INVALID_INPUT_CONTENT_TYPE:
                 return {
                     code: grpc.status.INVALID_ARGUMENT,
                     details: `${errors.reserved_prefixes.UNSUPPORTED_MEDIA_TYPE}: ${err.cause}`,

--- a/spec/streaming-pipeline.errors.spec.js
+++ b/spec/streaming-pipeline.errors.spec.js
@@ -436,7 +436,7 @@ describe("streaming pipeline =>", () => {
                 expect(err).toEqual({
                     code: grpc.status.INVALID_ARGUMENT,
                     details:
-                        "Invoker: Bad Request: SyntaxError: Unexpected token i in JSON at position 0",
+                        "Invoker: Bad Input Signal: SyntaxError: Unexpected token i in JSON at position 0",
                 });
             });
             finished(streamingPipeline, (err) => {

--- a/spec/streaming-pipeline.errors.spec.js
+++ b/spec/streaming-pipeline.errors.spec.js
@@ -436,7 +436,7 @@ describe("streaming pipeline =>", () => {
                 expect(err).toEqual({
                     code: grpc.status.INVALID_ARGUMENT,
                     details:
-                        "Invoker: Unexpected Error: SyntaxError: Unexpected token i in JSON at position 0",
+                        "Invoker: Bad Request: SyntaxError: Unexpected token i in JSON at position 0",
                 });
             });
             finished(streamingPipeline, (err) => {

--- a/spec/streaming-pipeline.errors.spec.js
+++ b/spec/streaming-pipeline.errors.spec.js
@@ -434,7 +434,7 @@ describe("streaming pipeline =>", () => {
             destinationStream.on("error", (err) => {
                 destinationErrored = true;
                 expect(err).toEqual({
-                    code: grpc.status.UNKNOWN,
+                    code: grpc.status.INVALID_ARGUMENT,
                     details:
                         "Invoker: Unexpected Error: SyntaxError: Unexpected token i in JSON at position 0",
                 });


### PR DESCRIPTION
grpc returns invalid arg code with error type INVALID_INPUT when encounter unmarshall errors, so that streaming-http-adapter can handle invalid json input as http 400 bad request